### PR TITLE
Bump the drmn module version.

### DIFF
--- a/amd/amdgpu/amdgpu_freebsd.c
+++ b/amd/amdgpu/amdgpu_freebsd.c
@@ -7,7 +7,7 @@ __FBSDID("$FreeBSD$");
 
 #include <drm/drm_crtc_helper.h>
 
-MODULE_DEPEND(amdgpu, drmn, 1, 1, 1);
+MODULE_DEPEND(amdgpu, drmn, 2, 2, 2);
 MODULE_DEPEND(amdgpu, agp, 1, 1, 1);
 MODULE_DEPEND(amdgpu, linuxkpi, 1, 1, 1);
 MODULE_DEPEND(amdgpu, linuxkpi_gplv2, 1, 1, 1);

--- a/drm/drm_os_freebsd.c
+++ b/drm/drm_os_freebsd.c
@@ -324,7 +324,7 @@ static moduledata_t drm_mod = {
 };
 
 DECLARE_MODULE(drmn, drm_mod, SI_SUB_DRIVERS, SI_ORDER_FIRST);
-MODULE_VERSION(drmn, 1);
+MODULE_VERSION(drmn, 2);
 MODULE_DEPEND(drmn, agp, 1, 1, 1);
 MODULE_DEPEND(drmn, pci, 1, 1, 1);
 MODULE_DEPEND(drmn, mem, 1, 1, 1);

--- a/i915/intel_freebsd.c
+++ b/i915/intel_freebsd.c
@@ -214,7 +214,7 @@ retry:
 	return (rc);
 }
 
-MODULE_DEPEND(i915kms, drmn, 1, 1, 1);
+MODULE_DEPEND(i915kms, drmn, 2, 2, 2);
 MODULE_DEPEND(i915kms, agp, 1, 1, 1);
 MODULE_DEPEND(i915kms, linuxkpi, 1, 1, 1);
 MODULE_DEPEND(i915kms, linuxkpi_gplv2, 1, 1, 1);

--- a/radeon/radeon_freebsd.c
+++ b/radeon/radeon_freebsd.c
@@ -7,7 +7,7 @@ __FBSDID("$FreeBSD$");
 
 #include <drm/drm_crtc_helper.h>
 
-MODULE_DEPEND(radeonkms, drmn, 1, 1, 1);
+MODULE_DEPEND(radeonkms, drmn, 2, 2, 2);
 MODULE_DEPEND(radeonkms, agp, 1, 1, 1);
 MODULE_DEPEND(radeonkms, linuxkpi, 1, 1, 1);
 MODULE_DEPEND(radeonkms, linuxkpi_gplv2, 1, 1, 1);


### PR DESCRIPTION
We currently set the module version to 1, which is the same as the
version of drmn in the base system (sys/dev/drm2). This means that
kldloading any of the kms-drm drivers will cause the base system's
drm2.ko to be loaded, which is of course not what we want.

With this change, a kldload of any of the kms-drm drivers (amdgpu,
radeon, i915) will automatically cause the right drm.ko to be loaded.