### PR TITLE
Call vga_pci_map_bios() on the right device.

### DIFF
--- a/amd/amdgpu/amdgpu_bios.c
+++ b/amd/amdgpu/amdgpu_bios.c
@@ -82,9 +82,9 @@ static bool igp_read_bios_from_vram(struct amdgpu_device *adev)
 
 #ifdef __FreeBSD__
 #define	pci_map_rom(pdev, sizep)			\
-	vga_pci_map_bios(pdev->dev.bsddev, sizep)
+	vga_pci_map_bios(device_get_parent(pdev->dev.bsddev), sizep)
 #define	pci_unmap_rom(pdev, bios)			\
-	vga_pci_unmap_bios(pdev->dev.bsddev, bios)
+	vga_pci_unmap_bios(device_get_parent(pdev->dev.bsddev), bios)
 #endif
 
 bool amdgpu_read_bios(struct amdgpu_device *adev)

--- a/i915/intel_bios.c
+++ b/i915/intel_bios.c
@@ -1448,9 +1448,9 @@ static const struct vbt_header *find_vbt(void __iomem *bios, size_t size)
 
 #ifdef __FreeBSD__
 #define	pci_map_rom(pdev, sizep)			\
-	vga_pci_map_bios(pdev->dev.bsddev, sizep)
+	vga_pci_map_bios(device_get_parent(pdev->dev.bsddev), sizep)
 #define	pci_unmap_rom(pdev, bios)			\
-	vga_pci_unmap_bios(pdev->dev.bsddev, bios)
+	vga_pci_unmap_bios(device_get_parent(pdev->dev.bsddev), bios)
 #endif
 
 /**

--- a/radeon/radeon_bios.c
+++ b/radeon/radeon_bios.c
@@ -75,9 +75,9 @@ static bool igp_read_bios_from_vram(struct radeon_device *rdev)
 
 #ifdef __FreeBSD__
 #define	pci_map_rom(pdev, sizep)			\
-	vga_pci_map_bios(pdev->dev.bsddev, sizep)
+	vga_pci_map_bios(device_get_parent(pdev->dev.bsddev), sizep)
 #define	pci_unmap_rom(pdev, bios)			\
-	vga_pci_unmap_bios(pdev->dev.bsddev, bios)
+	vga_pci_unmap_bios(device_get_parent(pdev->dev.bsddev), bios)
 #endif
 
 static bool radeon_read_bios(struct radeon_device *rdev)


### PR DESCRIPTION
This helps address issues encountered when more than
one DRM device is available.