### PR TITLE
Enable 32-bit compat drm ioctls

### DIFF
--- a/amd/amdgpu/Makefile
+++ b/amd/amdgpu/Makefile
@@ -38,6 +38,7 @@ SRCS=	amdgpu_acpi.c \
 	amdgpu_i2c.c \
 	amdgpu_ib.c \
 	amdgpu_ih.c \
+	amdgpu_ioc32.c \
 	amdgpu_irq.c \
 	amdgpu_job.c \
 	amdgpu_kms.c \

--- a/amd/amdgpu/amdgpu_ioc32.c
+++ b/amd/amdgpu/amdgpu_ioc32.c
@@ -31,8 +31,10 @@
 
 #include <drm/drmP.h>
 #include <drm/amdgpu_drm.h>
+#include "amdgpu.h"
 #include "amdgpu_drv.h"
 
+#ifdef CONFIG_COMPAT
 long amdgpu_kms_compat_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 {
 	unsigned int nr = DRM_IOCTL_NR(cmd);
@@ -45,3 +47,4 @@ long amdgpu_kms_compat_ioctl(struct file *filp, unsigned int cmd, unsigned long 
 
 	return ret;
 }
+#endif

--- a/drm/Makefile
+++ b/drm/Makefile
@@ -38,6 +38,7 @@ SRCS=	ati_pcigart.c \
 	drm_gem_cma_helper.c \
 	drm_global.c \
 	drm_hashtab.c \
+	drm_ioc32.c \
 	drm_ioctl.c \
 	drm_info.c \
 	drm_irq.c \

--- a/drm/drm_ioc32.c
+++ b/drm/drm_ioc32.c
@@ -1,4 +1,4 @@
-/**
+/*
  * \file drm_ioc32.c
  *
  * 32-bit ioctl compatibility routines for the DRM.
@@ -32,6 +32,22 @@
 #include <linux/export.h>
 
 #include <drm/drmP.h>
+#include "drm_legacy.h"
+#include "drm_internal.h"
+#include "drm_crtc_internal.h"
+
+#ifdef CONFIG_COMPAT
+#define compat_ptr(x)	((void *)(unsigned long)x)
+#define ptr_to_compat(x)	((unsigned long)x)
+
+extern int drm_version(struct drm_device *dev, void *data,
+			struct drm_file *file_priv);
+
+extern int drm_getunique(struct drm_device *dev, void *data,
+			struct drm_file *file_priv);
+
+extern int drm_getclient(struct drm_device *dev, void *data,
+			struct drm_file *file_priv);
 
 #define DRM_IOCTL_VERSION32		DRM_IOWR(0x00, drm_version32_t)
 #define DRM_IOCTL_GET_UNIQUE32		DRM_IOWR(0x01, drm_unique32_t)
@@ -72,88 +88,75 @@
 #define DRM_IOCTL_MODE_ADDFB232		DRM_IOWR(0xb8, drm_mode_fb_cmd232_t)
 
 typedef struct drm_version_32 {
-	int version_major;	  /**< Major version */
-	int version_minor;	  /**< Minor version */
-	int version_patchlevel;	   /**< Patch level */
-	u32 name_len;		  /**< Length of name buffer */
-	u32 name;		  /**< Name of driver */
-	u32 date_len;		  /**< Length of date buffer */
-	u32 date;		  /**< User-space buffer to hold date */
-	u32 desc_len;		  /**< Length of desc buffer */
-	u32 desc;		  /**< User-space buffer to hold desc */
+	int version_major;	  /* Major version */
+	int version_minor;	  /* Minor version */
+	int version_patchlevel;	   /* Patch level */
+	u32 name_len;		  /* Length of name buffer */
+	u32 name;		  /* Name of driver */
+	u32 date_len;		  /* Length of date buffer */
+	u32 date;		  /* User-space buffer to hold date */
+	u32 desc_len;		  /* Length of desc buffer */
+	u32 desc;		  /* User-space buffer to hold desc */
 } drm_version32_t;
 
 static int compat_drm_version(struct file *file, unsigned int cmd,
 			      unsigned long arg)
 {
 	drm_version32_t v32;
-	struct drm_version __user *version;
+	struct drm_version v;
 	int err;
 
 	if (copy_from_user(&v32, (void __user *)arg, sizeof(v32)))
 		return -EFAULT;
 
-	version = compat_alloc_user_space(sizeof(*version));
-	if (!version)
-		return -EFAULT;
-	if (__put_user(v32.name_len, &version->name_len)
-	    || __put_user((void __user *)(unsigned long)v32.name,
-			  &version->name)
-	    || __put_user(v32.date_len, &version->date_len)
-	    || __put_user((void __user *)(unsigned long)v32.date,
-			  &version->date)
-	    || __put_user(v32.desc_len, &version->desc_len)
-	    || __put_user((void __user *)(unsigned long)v32.desc,
-			  &version->desc))
-		return -EFAULT;
-
-	err = drm_ioctl(file,
-			DRM_IOCTL_VERSION, (unsigned long)version);
+	v = (struct drm_version) {
+		.name_len = v32.name_len,
+		.name = compat_ptr(v32.name),
+		.date_len = v32.date_len,
+		.date = compat_ptr(v32.date),
+		.desc_len = v32.desc_len,
+		.desc = compat_ptr(v32.desc),
+	};
+	err = drm_ioctl_kernel(file, drm_version, &v,
+			DRM_UNLOCKED|DRM_RENDER_ALLOW|DRM_CONTROL_ALLOW);
 	if (err)
 		return err;
 
-	if (__get_user(v32.version_major, &version->version_major)
-	    || __get_user(v32.version_minor, &version->version_minor)
-	    || __get_user(v32.version_patchlevel, &version->version_patchlevel)
-	    || __get_user(v32.name_len, &version->name_len)
-	    || __get_user(v32.date_len, &version->date_len)
-	    || __get_user(v32.desc_len, &version->desc_len))
-		return -EFAULT;
-
+	v32.version_major = v.version_major;
+	v32.version_minor = v.version_minor;
+	v32.version_patchlevel = v.version_patchlevel;
+	v32.name_len = v.name_len;
+	v32.date_len = v.date_len;
+	v32.desc_len = v.desc_len;
 	if (copy_to_user((void __user *)arg, &v32, sizeof(v32)))
 		return -EFAULT;
 	return 0;
 }
 
 typedef struct drm_unique32 {
-	u32 unique_len;	/**< Length of unique */
-	u32 unique;	/**< Unique name for driver instantiation */
+	u32 unique_len;	/* Length of unique */
+	u32 unique;	/* Unique name for driver instantiation */
 } drm_unique32_t;
 
 static int compat_drm_getunique(struct file *file, unsigned int cmd,
 				unsigned long arg)
 {
 	drm_unique32_t uq32;
-	struct drm_unique __user *u;
+	struct drm_unique uq;
 	int err;
 
 	if (copy_from_user(&uq32, (void __user *)arg, sizeof(uq32)))
 		return -EFAULT;
+	uq = (struct drm_unique){
+		.unique_len = uq32.unique_len,
+		.unique = compat_ptr(uq32.unique),
+	};
 
-	u = compat_alloc_user_space(sizeof(*u));
-	if (!u)
-		return -EFAULT;
-	if (__put_user(uq32.unique_len, &u->unique_len)
-	    || __put_user((void __user *)(unsigned long)uq32.unique,
-			  &u->unique))
-		return -EFAULT;
-
-	err = drm_ioctl(file, DRM_IOCTL_GET_UNIQUE, (unsigned long)u);
+	err = drm_ioctl_kernel(file, drm_getunique, &uq, DRM_UNLOCKED);
 	if (err)
 		return err;
 
-	if (__get_user(uq32.unique_len, &u->unique_len))
-		return -EFAULT;
+	uq32.unique_len = uq.unique_len;
 	if (copy_to_user((void __user *)arg, &uq32, sizeof(uq32)))
 		return -EFAULT;
 	return 0;
@@ -162,30 +165,17 @@ static int compat_drm_getunique(struct file *file, unsigned int cmd,
 static int compat_drm_setunique(struct file *file, unsigned int cmd,
 				unsigned long arg)
 {
-	drm_unique32_t uq32;
-	struct drm_unique __user *u;
-
-	if (copy_from_user(&uq32, (void __user *)arg, sizeof(uq32)))
-		return -EFAULT;
-
-	u = compat_alloc_user_space(sizeof(*u));
-	if (!u)
-		return -EFAULT;
-	if (__put_user(uq32.unique_len, &u->unique_len)
-	    || __put_user((void __user *)(unsigned long)uq32.unique,
-			  &u->unique))
-		return -EFAULT;
-
-	return drm_ioctl(file, DRM_IOCTL_SET_UNIQUE, (unsigned long)u);
+	/* it's dead */
+	return -EINVAL;
 }
 
 typedef struct drm_map32 {
-	u32 offset;		/**< Requested physical address (0 for SAREA)*/
-	u32 size;		/**< Requested physical size (bytes) */
-	enum drm_map_type type;	/**< Type of memory to map */
-	enum drm_map_flags flags;	/**< Flags */
-	u32 handle;		/**< User-space: "Handle" to pass to mmap() */
-	int mtrr;		/**< MTRR slot used */
+	u32 offset;		/* Requested physical address (0 for SAREA) */
+	u32 size;		/* Requested physical size (bytes) */
+	enum drm_map_type type;	/* Type of memory to map */
+	enum drm_map_flags flags;	/* Flags */
+	u32 handle;		/* User-space: "Handle" to pass to mmap() */
+	int mtrr;		/* MTRR slot used */
 } drm_map32_t;
 
 static int compat_drm_getmap(struct file *file, unsigned int cmd,
@@ -193,32 +183,23 @@ static int compat_drm_getmap(struct file *file, unsigned int cmd,
 {
 	drm_map32_t __user *argp = (void __user *)arg;
 	drm_map32_t m32;
-	struct drm_map __user *map;
-	int idx, err;
-	void *handle;
+	struct drm_map map;
+	int err;
 
-	if (get_user(idx, &argp->offset))
+	if (copy_from_user(&m32, argp, sizeof(m32)))
 		return -EFAULT;
 
-	map = compat_alloc_user_space(sizeof(*map));
-	if (!map)
-		return -EFAULT;
-	if (__put_user(idx, &map->offset))
-		return -EFAULT;
-
-	err = drm_ioctl(file, DRM_IOCTL_GET_MAP, (unsigned long)map);
+	map.offset = m32.offset;
+	err = drm_ioctl_kernel(file, drm_legacy_getmap_ioctl, &map, DRM_UNLOCKED);
 	if (err)
 		return err;
 
-	if (__get_user(m32.offset, &map->offset)
-	    || __get_user(m32.size, &map->size)
-	    || __get_user(m32.type, &map->type)
-	    || __get_user(m32.flags, &map->flags)
-	    || __get_user(handle, &map->handle)
-	    || __get_user(m32.mtrr, &map->mtrr))
-		return -EFAULT;
-
-	m32.handle = (unsigned long)handle;
+	m32.offset = map.offset;
+	m32.size = map.size;
+	m32.type = map.type;
+	m32.flags = map.flags;
+	m32.handle = ptr_to_compat(map.handle);
+	m32.mtrr = map.mtrr;
 	if (copy_to_user(argp, &m32, sizeof(m32)))
 		return -EFAULT;
 	return 0;
@@ -230,36 +211,28 @@ static int compat_drm_addmap(struct file *file, unsigned int cmd,
 {
 	drm_map32_t __user *argp = (void __user *)arg;
 	drm_map32_t m32;
-	struct drm_map __user *map;
+	struct drm_map map;
 	int err;
-	void *handle;
 
 	if (copy_from_user(&m32, argp, sizeof(m32)))
 		return -EFAULT;
 
-	map = compat_alloc_user_space(sizeof(*map));
-	if (!map)
-		return -EFAULT;
-	if (__put_user(m32.offset, &map->offset)
-	    || __put_user(m32.size, &map->size)
-	    || __put_user(m32.type, &map->type)
-	    || __put_user(m32.flags, &map->flags))
-		return -EFAULT;
+	map.offset = m32.offset;
+	map.size = m32.size;
+	map.type = m32.type;
+	map.flags = m32.flags;
 
-	err = drm_ioctl(file, DRM_IOCTL_ADD_MAP, (unsigned long)map);
+	err = drm_ioctl_kernel(file, drm_legacy_addmap_ioctl, &map,
+				DRM_AUTH|DRM_MASTER|DRM_ROOT_ONLY);
 	if (err)
 		return err;
 
-	if (__get_user(m32.offset, &map->offset)
-	    || __get_user(m32.mtrr, &map->mtrr)
-	    || __get_user(handle, &map->handle))
-		return -EFAULT;
-
-	m32.handle = (unsigned long)handle;
-	if (m32.handle != (unsigned long)handle)
-		printk_ratelimited(KERN_ERR "compat_drm_addmap truncated handle"
-				   " %p for type %d offset %x\n",
-				   handle, m32.type, m32.offset);
+	m32.offset = map.offset;
+	m32.mtrr = map.mtrr;
+	m32.handle = ptr_to_compat(map.handle);
+	if (map.handle != compat_ptr(m32.handle))
+		printk_ratelimited("compat_drm_addmap truncated handle %p for type %d offset %x\n",
+				   map.handle, m32.type, m32.offset);
 
 	if (copy_to_user(argp, &m32, sizeof(m32)))
 		return -EFAULT;
@@ -271,28 +244,22 @@ static int compat_drm_rmmap(struct file *file, unsigned int cmd,
 			    unsigned long arg)
 {
 	drm_map32_t __user *argp = (void __user *)arg;
-	struct drm_map __user *map;
+	struct drm_map map;
 	u32 handle;
 
 	if (get_user(handle, &argp->handle))
 		return -EFAULT;
-
-	map = compat_alloc_user_space(sizeof(*map));
-	if (!map)
-		return -EFAULT;
-	if (__put_user((void *)(unsigned long)handle, &map->handle))
-		return -EFAULT;
-
-	return drm_ioctl(file, DRM_IOCTL_RM_MAP, (unsigned long)map);
+	map.handle = compat_ptr(handle);
+	return drm_ioctl_kernel(file, drm_legacy_rmmap_ioctl, &map, DRM_AUTH);
 }
 
 typedef struct drm_client32 {
-	int idx;	/**< Which client desired? */
-	int auth;	/**< Is client authenticated? */
-	u32 pid;	/**< Process ID */
-	u32 uid;	/**< User ID */
-	u32 magic;	/**< Magic */
-	u32 iocs;	/**< Ioctl count */
+	int idx;	/* Which client desired? */
+	int auth;	/* Is client authenticated? */
+	u32 pid;	/* Process ID */
+	u32 uid;	/* User ID */
+	u32 magic;	/* Magic */
+	u32 iocs;	/* Ioctl count */
 } drm_client32_t;
 
 static int compat_drm_getclient(struct file *file, unsigned int cmd,
@@ -300,29 +267,24 @@ static int compat_drm_getclient(struct file *file, unsigned int cmd,
 {
 	drm_client32_t c32;
 	drm_client32_t __user *argp = (void __user *)arg;
-	struct drm_client __user *client;
-	int idx, err;
+	struct drm_client client;
+	int err;
 
-	if (get_user(idx, &argp->idx))
+	if (copy_from_user(&c32, argp, sizeof(c32)))
 		return -EFAULT;
 
-	client = compat_alloc_user_space(sizeof(*client));
-	if (!client)
-		return -EFAULT;
-	if (__put_user(idx, &client->idx))
-		return -EFAULT;
+	client.idx = c32.idx;
 
-	err = drm_ioctl(file, DRM_IOCTL_GET_CLIENT, (unsigned long)client);
+	err = drm_ioctl_kernel(file, drm_getclient, &client, DRM_UNLOCKED);
 	if (err)
 		return err;
 
-	if (__get_user(c32.idx, &client->idx)
-	    || __get_user(c32.auth, &client->auth)
-	    || __get_user(c32.pid, &client->pid)
-	    || __get_user(c32.uid, &client->uid)
-	    || __get_user(c32.magic, &client->magic)
-	    || __get_user(c32.iocs, &client->iocs))
-		return -EFAULT;
+	c32.idx = client.idx;
+	c32.auth = client.auth;
+	c32.pid = client.pid;
+	c32.uid = client.uid;
+	c32.magic = client.magic;
+	c32.iocs = client.iocs;
 
 	if (copy_to_user(argp, &c32, sizeof(c32)))
 		return -EFAULT;
@@ -340,65 +302,53 @@ typedef struct drm_stats32 {
 static int compat_drm_getstats(struct file *file, unsigned int cmd,
 			       unsigned long arg)
 {
-	drm_stats32_t s32;
 	drm_stats32_t __user *argp = (void __user *)arg;
-	struct drm_stats __user *stats;
-	int i, err;
+	int err;
 
-	memset(&s32, 0, sizeof(drm_stats32_t));
-	stats = compat_alloc_user_space(sizeof(*stats));
-	if (!stats)
-		return -EFAULT;
-
-	err = drm_ioctl(file, DRM_IOCTL_GET_STATS, (unsigned long)stats);
+	err = drm_ioctl_kernel(file, drm_noop, NULL, DRM_UNLOCKED);
 	if (err)
 		return err;
 
-	if (__get_user(s32.count, &stats->count))
-		return -EFAULT;
-	for (i = 0; i < 15; ++i)
-		if (__get_user(s32.data[i].value, &stats->data[i].value)
-		    || __get_user(s32.data[i].type, &stats->data[i].type))
-			return -EFAULT;
-
-	if (copy_to_user(argp, &s32, sizeof(s32)))
+	if (clear_user(argp, sizeof(drm_stats32_t)))
 		return -EFAULT;
 	return 0;
 }
 
 typedef struct drm_buf_desc32 {
-	int count;		 /**< Number of buffers of this size */
-	int size;		 /**< Size in bytes */
-	int low_mark;		 /**< Low water mark */
-	int high_mark;		 /**< High water mark */
+	int count;		 /* Number of buffers of this size */
+	int size;		 /* Size in bytes */
+	int low_mark;		 /* Low water mark */
+	int high_mark;		 /* High water mark */
 	int flags;
-	u32 agp_start;		 /**< Start address in the AGP aperture */
+	u32 agp_start;		 /* Start address in the AGP aperture */
 } drm_buf_desc32_t;
 
 static int compat_drm_addbufs(struct file *file, unsigned int cmd,
 			      unsigned long arg)
 {
 	drm_buf_desc32_t __user *argp = (void __user *)arg;
-	struct drm_buf_desc __user *buf;
+	drm_buf_desc32_t desc32;
+	struct drm_buf_desc desc;
 	int err;
-	unsigned long agp_start;
 
-	buf = compat_alloc_user_space(sizeof(*buf));
-	if (!buf || !access_ok(VERIFY_WRITE, argp, sizeof(*argp)))
+	if (copy_from_user(&desc32, argp, sizeof(drm_buf_desc32_t)))
 		return -EFAULT;
 
-	if (__copy_in_user(buf, argp, offsetof(drm_buf_desc32_t, agp_start))
-	    || __get_user(agp_start, &argp->agp_start)
-	    || __put_user(agp_start, &buf->agp_start))
-		return -EFAULT;
+	desc = (struct drm_buf_desc){
+		desc32.count, desc32.size, desc32.low_mark, desc32.high_mark,
+		desc32.flags, desc32.agp_start
+	};
 
-	err = drm_ioctl(file, DRM_IOCTL_ADD_BUFS, (unsigned long)buf);
+	err = drm_ioctl_kernel(file, drm_legacy_addbufs, &desc,
+				   DRM_AUTH|DRM_MASTER|DRM_ROOT_ONLY);
 	if (err)
 		return err;
 
-	if (__copy_in_user(argp, buf, offsetof(drm_buf_desc32_t, agp_start))
-	    || __get_user(agp_start, &buf->agp_start)
-	    || __put_user(agp_start, &argp->agp_start))
+	desc32 = (drm_buf_desc32_t){
+		desc.count, desc.size, desc.low_mark, desc.high_mark,
+		desc.flags, desc.agp_start
+	};
+	if (copy_to_user(argp, &desc32, sizeof(drm_buf_desc32_t)))
 		return -EFAULT;
 
 	return 0;
@@ -409,21 +359,17 @@ static int compat_drm_markbufs(struct file *file, unsigned int cmd,
 {
 	drm_buf_desc32_t b32;
 	drm_buf_desc32_t __user *argp = (void __user *)arg;
-	struct drm_buf_desc __user *buf;
+	struct drm_buf_desc buf;
 
 	if (copy_from_user(&b32, argp, sizeof(b32)))
 		return -EFAULT;
 
-	buf = compat_alloc_user_space(sizeof(*buf));
-	if (!buf)
-		return -EFAULT;
+	buf.size = b32.size;
+	buf.low_mark = b32.low_mark;
+	buf.high_mark = b32.high_mark;
 
-	if (__put_user(b32.size, &buf->size)
-	    || __put_user(b32.low_mark, &buf->low_mark)
-	    || __put_user(b32.high_mark, &buf->high_mark))
-		return -EFAULT;
-
-	return drm_ioctl(file, DRM_IOCTL_MARK_BUFS, (unsigned long)buf);
+	return drm_ioctl_kernel(file, drm_legacy_markbufs, &buf,
+				DRM_AUTH|DRM_MASTER|DRM_ROOT_ONLY);
 }
 
 typedef struct drm_buf_info32 {
@@ -431,52 +377,35 @@ typedef struct drm_buf_info32 {
 	u32 list;
 } drm_buf_info32_t;
 
+static int copy_one_buf32(void *data, int count, struct drm_buf_entry *from)
+{
+	drm_buf_info32_t *request = data;
+	drm_buf_desc32_t __user *to = compat_ptr(request->list);
+	drm_buf_desc32_t v = {.count = from->buf_count,
+			      .size = from->buf_size,
+			      .low_mark = from->low_mark,
+			      .high_mark = from->high_mark};
+	return copy_to_user(to + count, &v, offsetof(drm_buf_desc32_t, flags));
+}
+
 static int compat_drm_infobufs(struct file *file, unsigned int cmd,
 			       unsigned long arg)
 {
 	drm_buf_info32_t req32;
 	drm_buf_info32_t __user *argp = (void __user *)arg;
-	drm_buf_desc32_t __user *to;
-	struct drm_buf_info __user *request;
-	struct drm_buf_desc __user *list;
-	size_t nbytes;
-	int i, err;
-	int count, actual;
+	int err;
 
 	if (copy_from_user(&req32, argp, sizeof(req32)))
 		return -EFAULT;
 
-	count = req32.count;
-	to = (drm_buf_desc32_t __user *) (unsigned long)req32.list;
-	if (count < 0)
-		count = 0;
-	if (count > 0
-	    && !access_ok(VERIFY_WRITE, to, count * sizeof(drm_buf_desc32_t)))
-		return -EFAULT;
+	if (req32.count < 0)
+		req32.count = 0;
 
-	nbytes = sizeof(*request) + count * sizeof(struct drm_buf_desc);
-	request = compat_alloc_user_space(nbytes);
-	if (!request)
-		return -EFAULT;
-	list = (struct drm_buf_desc *) (request + 1);
-
-	if (__put_user(count, &request->count)
-	    || __put_user(list, &request->list))
-		return -EFAULT;
-
-	err = drm_ioctl(file, DRM_IOCTL_INFO_BUFS, (unsigned long)request);
+	err = drm_ioctl_kernel(file, drm_legacy_infobufs, &req32, DRM_AUTH);
 	if (err)
 		return err;
 
-	if (__get_user(actual, &request->count))
-		return -EFAULT;
-	if (count >= actual)
-		for (i = 0; i < actual; ++i)
-			if (__copy_in_user(&to[i], &list[i],
-					   offsetof(struct drm_buf_desc, flags)))
-				return -EFAULT;
-
-	if (__put_user(actual, &argp->count))
+	if (put_user(req32.count, &argp->count))
 		return -EFAULT;
 
 	return 0;
@@ -495,54 +424,40 @@ typedef struct drm_buf_map32 {
 	u32 list;		/**< Buffer information */
 } drm_buf_map32_t;
 
+static int map_one_buf32(void *data, int idx, unsigned long virtual,
+			struct drm_buf *buf)
+{
+	drm_buf_map32_t *request = data;
+	drm_buf_pub32_t __user *to = compat_ptr(request->list) + idx;
+	drm_buf_pub32_t v;
+
+	v.idx = buf->idx;
+	v.total = buf->total;
+	v.used = 0;
+	v.address = virtual + buf->offset;
+	if (copy_to_user(to, &v, sizeof(v)))
+		return -EFAULT;
+	return 0;
+}
+
 static int compat_drm_mapbufs(struct file *file, unsigned int cmd,
 			      unsigned long arg)
 {
 	drm_buf_map32_t __user *argp = (void __user *)arg;
 	drm_buf_map32_t req32;
-	drm_buf_pub32_t __user *list32;
-	struct drm_buf_map __user *request;
-	struct drm_buf_pub __user *list;
-	int i, err;
-	int count, actual;
-	size_t nbytes;
-	void __user *addr;
+	int err;
 
 	if (copy_from_user(&req32, argp, sizeof(req32)))
 		return -EFAULT;
-	count = req32.count;
-	list32 = (void __user *)(unsigned long)req32.list;
-
-	if (count < 0)
+	if (req32.count < 0)
 		return -EINVAL;
-	nbytes = sizeof(*request) + count * sizeof(struct drm_buf_pub);
-	request = compat_alloc_user_space(nbytes);
-	if (!request)
-		return -EFAULT;
-	list = (struct drm_buf_pub *) (request + 1);
 
-	if (__put_user(count, &request->count)
-	    || __put_user(list, &request->list))
-		return -EFAULT;
-
-	err = drm_ioctl(file, DRM_IOCTL_MAP_BUFS, (unsigned long)request);
+	err = drm_ioctl_kernel(file, drm_legacy_mapbufs, &req32, DRM_AUTH);
 	if (err)
 		return err;
 
-	if (__get_user(actual, &request->count))
-		return -EFAULT;
-	if (count >= actual)
-		for (i = 0; i < actual; ++i)
-			if (__copy_in_user(&list32[i], &list[i],
-					   offsetof(struct drm_buf_pub, address))
-			    || __get_user(addr, &list[i].address)
-			    || __put_user((unsigned long)addr,
-					  &list32[i].address))
-				return -EFAULT;
-
-	if (__put_user(actual, &argp->count)
-	    || __get_user(addr, &request->virtual)
-	    || __put_user((unsigned long)addr, &argp->virtual))
+	if (put_user(req32.count, &argp->count)
+	    || put_user(req32.virtual, &argp->virtual))
 		return -EFAULT;
 
 	return 0;
@@ -557,21 +472,15 @@ static int compat_drm_freebufs(struct file *file, unsigned int cmd,
 			       unsigned long arg)
 {
 	drm_buf_free32_t req32;
-	struct drm_buf_free __user *request;
+	struct drm_buf_free request;
 	drm_buf_free32_t __user *argp = (void __user *)arg;
 
 	if (copy_from_user(&req32, argp, sizeof(req32)))
 		return -EFAULT;
 
-	request = compat_alloc_user_space(sizeof(*request));
-	if (!request)
-		return -EFAULT;
-	if (__put_user(req32.count, &request->count)
-	    || __put_user((int __user *)(unsigned long)req32.list,
-			  &request->list))
-		return -EFAULT;
-
-	return drm_ioctl(file, DRM_IOCTL_FREE_BUFS, (unsigned long)request);
+	request.count = req32.count;
+	request.list = compat_ptr(req32.list);
+	return drm_ioctl_kernel(file, drm_legacy_freebufs, &request, DRM_AUTH);
 }
 
 typedef struct drm_ctx_priv_map32 {
@@ -583,48 +492,36 @@ static int compat_drm_setsareactx(struct file *file, unsigned int cmd,
 				  unsigned long arg)
 {
 	drm_ctx_priv_map32_t req32;
-	struct drm_ctx_priv_map __user *request;
+	struct drm_ctx_priv_map request;
 	drm_ctx_priv_map32_t __user *argp = (void __user *)arg;
 
 	if (copy_from_user(&req32, argp, sizeof(req32)))
 		return -EFAULT;
 
-	request = compat_alloc_user_space(sizeof(*request));
-	if (!request)
-		return -EFAULT;
-	if (__put_user(req32.ctx_id, &request->ctx_id)
-	    || __put_user((void *)(unsigned long)req32.handle,
-			  &request->handle))
-		return -EFAULT;
-
-	return drm_ioctl(file, DRM_IOCTL_SET_SAREA_CTX, (unsigned long)request);
+	request.ctx_id = req32.ctx_id;
+	request.handle = compat_ptr(req32.handle);
+	return drm_ioctl_kernel(file, drm_legacy_setsareactx, &request,
+				DRM_AUTH|DRM_MASTER|DRM_ROOT_ONLY);
 }
 
 static int compat_drm_getsareactx(struct file *file, unsigned int cmd,
 				  unsigned long arg)
 {
-	struct drm_ctx_priv_map __user *request;
+	struct drm_ctx_priv_map req;
+	drm_ctx_priv_map32_t req32;
 	drm_ctx_priv_map32_t __user *argp = (void __user *)arg;
 	int err;
-	unsigned int ctx_id;
-	void *handle;
 
-	if (!access_ok(VERIFY_WRITE, argp, sizeof(*argp))
-	    || __get_user(ctx_id, &argp->ctx_id))
+	if (copy_from_user(&req32, argp, sizeof(req32)))
 		return -EFAULT;
 
-	request = compat_alloc_user_space(sizeof(*request));
-	if (!request)
-		return -EFAULT;
-	if (__put_user(ctx_id, &request->ctx_id))
-		return -EFAULT;
-
-	err = drm_ioctl(file, DRM_IOCTL_GET_SAREA_CTX, (unsigned long)request);
+	req.ctx_id = req32.ctx_id;
+	err = drm_ioctl_kernel(file, drm_legacy_getsareactx, &req, DRM_AUTH);
 	if (err)
 		return err;
 
-	if (__get_user(handle, &request->handle)
-	    || __put_user((unsigned long)handle, &argp->handle))
+	req32.handle = ptr_to_compat(req.handle);
+	if (copy_to_user(argp, &req32, sizeof(req32)))
 		return -EFAULT;
 
 	return 0;
@@ -640,26 +537,20 @@ static int compat_drm_resctx(struct file *file, unsigned int cmd,
 {
 	drm_ctx_res32_t __user *argp = (void __user *)arg;
 	drm_ctx_res32_t res32;
-	struct drm_ctx_res __user *res;
+	struct drm_ctx_res res;
 	int err;
 
 	if (copy_from_user(&res32, argp, sizeof(res32)))
 		return -EFAULT;
 
-	res = compat_alloc_user_space(sizeof(*res));
-	if (!res)
-		return -EFAULT;
-	if (__put_user(res32.count, &res->count)
-	    || __put_user((struct drm_ctx __user *) (unsigned long)res32.contexts,
-			  &res->contexts))
-		return -EFAULT;
-
-	err = drm_ioctl(file, DRM_IOCTL_RES_CTX, (unsigned long)res);
+	res.count = res32.count;
+	res.contexts = compat_ptr(res32.contexts);
+	err = drm_ioctl_kernel(file, drm_legacy_resctx, &res, DRM_AUTH);
 	if (err)
 		return err;
 
-	if (__get_user(res32.count, &res->count)
-	    || __put_user(res32.count, &argp->count))
+	res32.count = res.count;
+	if (copy_to_user(argp, &res32, sizeof(res32)))
 		return -EFAULT;
 
 	return 0;
@@ -683,38 +574,26 @@ static int compat_drm_dma(struct file *file, unsigned int cmd,
 {
 	drm_dma32_t d32;
 	drm_dma32_t __user *argp = (void __user *)arg;
-	struct drm_dma __user *d;
+	struct drm_dma d;
 	int err;
 
 	if (copy_from_user(&d32, argp, sizeof(d32)))
 		return -EFAULT;
 
-	d = compat_alloc_user_space(sizeof(*d));
-	if (!d)
-		return -EFAULT;
-
-	if (__put_user(d32.context, &d->context)
-	    || __put_user(d32.send_count, &d->send_count)
-	    || __put_user((int __user *)(unsigned long)d32.send_indices,
-			  &d->send_indices)
-	    || __put_user((int __user *)(unsigned long)d32.send_sizes,
-			  &d->send_sizes)
-	    || __put_user(d32.flags, &d->flags)
-	    || __put_user(d32.request_count, &d->request_count)
-	    || __put_user((int __user *)(unsigned long)d32.request_indices,
-			  &d->request_indices)
-	    || __put_user((int __user *)(unsigned long)d32.request_sizes,
-			  &d->request_sizes))
-		return -EFAULT;
-
-	err = drm_ioctl(file, DRM_IOCTL_DMA, (unsigned long)d);
+	d.context = d32.context;
+	d.send_count = d32.send_count;
+	d.send_indices = compat_ptr(d32.send_indices);
+	d.send_sizes = compat_ptr(d32.send_sizes);
+	d.flags = d32.flags;
+	d.request_count = d32.request_count;
+	d.request_indices = compat_ptr(d32.request_indices);
+	d.request_sizes = compat_ptr(d32.request_sizes);
+	err = drm_ioctl_kernel(file, drm_legacy_dma_ioctl, &d, DRM_AUTH);
 	if (err)
 		return err;
 
-	if (__get_user(d32.request_size, &d->request_size)
-	    || __get_user(d32.granted_count, &d->granted_count)
-	    || __put_user(d32.request_size, &argp->request_size)
-	    || __put_user(d32.granted_count, &argp->granted_count))
+	if (put_user(d.request_size, &argp->request_size)
+	    || put_user(d.granted_count, &argp->granted_count))
 		return -EFAULT;
 
 	return 0;
@@ -729,17 +608,13 @@ static int compat_drm_agp_enable(struct file *file, unsigned int cmd,
 				 unsigned long arg)
 {
 	drm_agp_mode32_t __user *argp = (void __user *)arg;
-	drm_agp_mode32_t m32;
-	struct drm_agp_mode __user *mode;
+	struct drm_agp_mode mode;
 
-	if (get_user(m32.mode, &argp->mode))
+	if (get_user(mode.mode, &argp->mode))
 		return -EFAULT;
 
-	mode = compat_alloc_user_space(sizeof(*mode));
-	if (put_user(m32.mode, &mode->mode))
-		return -EFAULT;
-
-	return drm_ioctl(file, DRM_IOCTL_AGP_ENABLE, (unsigned long)mode);
+	return drm_ioctl_kernel(file,  drm_agp_enable_ioctl, &mode,
+				DRM_AUTH|DRM_MASTER|DRM_ROOT_ONLY);
 }
 
 typedef struct drm_agp_info32 {
@@ -761,28 +636,22 @@ static int compat_drm_agp_info(struct file *file, unsigned int cmd,
 {
 	drm_agp_info32_t __user *argp = (void __user *)arg;
 	drm_agp_info32_t i32;
-	struct drm_agp_info __user *info;
+	struct drm_agp_info info;
 	int err;
 
-	info = compat_alloc_user_space(sizeof(*info));
-	if (!info)
-		return -EFAULT;
-
-	err = drm_ioctl(file, DRM_IOCTL_AGP_INFO, (unsigned long)info);
+	err = drm_ioctl_kernel(file, drm_agp_info_ioctl, &info, DRM_AUTH);
 	if (err)
 		return err;
 
-	if (__get_user(i32.agp_version_major, &info->agp_version_major)
-	    || __get_user(i32.agp_version_minor, &info->agp_version_minor)
-	    || __get_user(i32.mode, &info->mode)
-	    || __get_user(i32.aperture_base, &info->aperture_base)
-	    || __get_user(i32.aperture_size, &info->aperture_size)
-	    || __get_user(i32.memory_allowed, &info->memory_allowed)
-	    || __get_user(i32.memory_used, &info->memory_used)
-	    || __get_user(i32.id_vendor, &info->id_vendor)
-	    || __get_user(i32.id_device, &info->id_device))
-		return -EFAULT;
-
+	i32.agp_version_major = info.agp_version_major;
+	i32.agp_version_minor = info.agp_version_minor;
+	i32.mode = info.mode;
+	i32.aperture_base = info.aperture_base;
+	i32.aperture_size = info.aperture_size;
+	i32.memory_allowed = info.memory_allowed;
+	i32.memory_used = info.memory_used;
+	i32.id_vendor = info.id_vendor;
+	i32.id_device = info.id_device;
 	if (copy_to_user(argp, &i32, sizeof(i32)))
 		return -EFAULT;
 
@@ -801,26 +670,24 @@ static int compat_drm_agp_alloc(struct file *file, unsigned int cmd,
 {
 	drm_agp_buffer32_t __user *argp = (void __user *)arg;
 	drm_agp_buffer32_t req32;
-	struct drm_agp_buffer __user *request;
+	struct drm_agp_buffer request;
 	int err;
 
 	if (copy_from_user(&req32, argp, sizeof(req32)))
 		return -EFAULT;
 
-	request = compat_alloc_user_space(sizeof(*request));
-	if (!request
-	    || __put_user(req32.size, &request->size)
-	    || __put_user(req32.type, &request->type))
-		return -EFAULT;
-
-	err = drm_ioctl(file, DRM_IOCTL_AGP_ALLOC, (unsigned long)request);
+	request.size = req32.size;
+	request.type = req32.type;
+	err = drm_ioctl_kernel(file, drm_agp_alloc_ioctl, &request,
+				DRM_AUTH|DRM_MASTER|DRM_ROOT_ONLY);
 	if (err)
 		return err;
 
-	if (__get_user(req32.handle, &request->handle)
-	    || __get_user(req32.physical, &request->physical)
-	    || copy_to_user(argp, &req32, sizeof(req32))) {
-		drm_ioctl(file, DRM_IOCTL_AGP_FREE, (unsigned long)request);
+	req32.handle = request.handle;
+	req32.physical = request.physical;
+	if (copy_to_user(argp, &req32, sizeof(req32))) {
+		drm_ioctl_kernel(file, drm_agp_free_ioctl, &request,
+				DRM_AUTH|DRM_MASTER|DRM_ROOT_ONLY);
 		return -EFAULT;
 	}
 
@@ -831,16 +698,13 @@ static int compat_drm_agp_free(struct file *file, unsigned int cmd,
 			       unsigned long arg)
 {
 	drm_agp_buffer32_t __user *argp = (void __user *)arg;
-	struct drm_agp_buffer __user *request;
-	u32 handle;
+	struct drm_agp_buffer request;
 
-	request = compat_alloc_user_space(sizeof(*request));
-	if (!request
-	    || get_user(handle, &argp->handle)
-	    || __put_user(handle, &request->handle))
+	if (get_user(request.handle, &argp->handle))
 		return -EFAULT;
 
-	return drm_ioctl(file, DRM_IOCTL_AGP_FREE, (unsigned long)request);
+	return drm_ioctl_kernel(file, drm_agp_free_ioctl, &request,
+				DRM_AUTH|DRM_MASTER|DRM_ROOT_ONLY);
 }
 
 typedef struct drm_agp_binding32 {
@@ -853,34 +717,28 @@ static int compat_drm_agp_bind(struct file *file, unsigned int cmd,
 {
 	drm_agp_binding32_t __user *argp = (void __user *)arg;
 	drm_agp_binding32_t req32;
-	struct drm_agp_binding __user *request;
+	struct drm_agp_binding request;
 
 	if (copy_from_user(&req32, argp, sizeof(req32)))
 		return -EFAULT;
 
-	request = compat_alloc_user_space(sizeof(*request));
-	if (!request
-	    || __put_user(req32.handle, &request->handle)
-	    || __put_user(req32.offset, &request->offset))
-		return -EFAULT;
-
-	return drm_ioctl(file, DRM_IOCTL_AGP_BIND, (unsigned long)request);
+	request.handle = req32.handle;
+	request.offset = req32.offset;
+	return drm_ioctl_kernel(file, drm_agp_bind_ioctl, &request,
+				DRM_AUTH|DRM_MASTER|DRM_ROOT_ONLY);
 }
 
 static int compat_drm_agp_unbind(struct file *file, unsigned int cmd,
 				 unsigned long arg)
 {
 	drm_agp_binding32_t __user *argp = (void __user *)arg;
-	struct drm_agp_binding __user *request;
-	u32 handle;
+	struct drm_agp_binding request;
 
-	request = compat_alloc_user_space(sizeof(*request));
-	if (!request
-	    || get_user(handle, &argp->handle)
-	    || __put_user(handle, &request->handle))
+	if (get_user(request.handle, &argp->handle))
 		return -EFAULT;
 
-	return drm_ioctl(file, DRM_IOCTL_AGP_UNBIND, (unsigned long)request);
+	return drm_ioctl_kernel(file, drm_agp_unbind_ioctl, &request,
+				DRM_AUTH|DRM_MASTER|DRM_ROOT_ONLY);
 }
 #endif /* CONFIG_AGP */
 
@@ -893,23 +751,21 @@ static int compat_drm_sg_alloc(struct file *file, unsigned int cmd,
 			       unsigned long arg)
 {
 	drm_scatter_gather32_t __user *argp = (void __user *)arg;
-	struct drm_scatter_gather __user *request;
+	struct drm_scatter_gather request;
 	int err;
-	unsigned long x;
+	unsigned long handle;
 
-	request = compat_alloc_user_space(sizeof(*request));
-	if (!request || !access_ok(VERIFY_WRITE, argp, sizeof(*argp))
-	    || __get_user(x, &argp->size)
-	    || __put_user(x, &request->size))
+	if (get_user(request.size, &argp->size))
 		return -EFAULT;
 
-	err = drm_ioctl(file, DRM_IOCTL_SG_ALLOC, (unsigned long)request);
+	err = drm_ioctl_kernel(file, drm_legacy_sg_alloc, &request,
+				DRM_AUTH|DRM_MASTER|DRM_ROOT_ONLY);
 	if (err)
 		return err;
 
 	/* XXX not sure about the handle conversion here... */
-	if (__get_user(x, &request->handle)
-	    || __put_user(x >> PAGE_SHIFT, &argp->handle))
+	handle = request.handle >> PAGE_SHIFT;
+	if (put_user(handle, &argp->handle))
 		return -EFAULT;
 
 	return 0;
@@ -919,19 +775,17 @@ static int compat_drm_sg_free(struct file *file, unsigned int cmd,
 			      unsigned long arg)
 {
 	drm_scatter_gather32_t __user *argp = (void __user *)arg;
-	struct drm_scatter_gather __user *request;
+	struct drm_scatter_gather request;
 	unsigned long x;
 
-	request = compat_alloc_user_space(sizeof(*request));
-	if (!request || !access_ok(VERIFY_WRITE, argp, sizeof(*argp))
-	    || __get_user(x, &argp->handle)
-	    || __put_user(x << PAGE_SHIFT, &request->handle))
+	if (get_user(x, &argp->handle))
 		return -EFAULT;
-
-	return drm_ioctl(file, DRM_IOCTL_SG_FREE, (unsigned long)request);
+	request.handle = x << PAGE_SHIFT;
+	return drm_ioctl_kernel(file, drm_legacy_sg_free, &request,
+				DRM_AUTH|DRM_MASTER|DRM_ROOT_ONLY);
 }
 
-#if defined(CONFIG_X86) || defined(CONFIG_IA64)
+#if defined(CONFIG_X86)
 typedef struct drm_update_draw32 {
 	drm_drawable_t handle;
 	unsigned int type;
@@ -944,22 +798,11 @@ static int compat_drm_update_draw(struct file *file, unsigned int cmd,
 				  unsigned long arg)
 {
 	drm_update_draw32_t update32;
-	struct drm_update_draw __user *request;
-	int err;
-
 	if (copy_from_user(&update32, (void __user *)arg, sizeof(update32)))
 		return -EFAULT;
 
-	request = compat_alloc_user_space(sizeof(*request));
-	if (!request ||
-	    __put_user(update32.handle, &request->handle) ||
-	    __put_user(update32.type, &request->type) ||
-	    __put_user(update32.num, &request->num) ||
-	    __put_user(update32.data, &request->data))
-		return -EFAULT;
-
-	err = drm_ioctl(file, DRM_IOCTL_UPDATE_DRAW, (unsigned long)request);
-	return err;
+	return drm_ioctl_kernel(file, drm_noop, NULL,
+				DRM_AUTH|DRM_MASTER|DRM_ROOT_ONLY);
 }
 #endif
 
@@ -986,36 +829,30 @@ static int compat_drm_wait_vblank(struct file *file, unsigned int cmd,
 {
 	drm_wait_vblank32_t __user *argp = (void __user *)arg;
 	drm_wait_vblank32_t req32;
-	union drm_wait_vblank __user *request;
+	union drm_wait_vblank req;
 	int err;
 
 	if (copy_from_user(&req32, argp, sizeof(req32)))
 		return -EFAULT;
 
-	request = compat_alloc_user_space(sizeof(*request));
-	if (!request
-	    || __put_user(req32.request.type, &request->request.type)
-	    || __put_user(req32.request.sequence, &request->request.sequence)
-	    || __put_user(req32.request.signal, &request->request.signal))
-		return -EFAULT;
-
-	err = drm_ioctl(file, DRM_IOCTL_WAIT_VBLANK, (unsigned long)request);
+	req.request.type = req32.request.type;
+	req.request.sequence = req32.request.sequence;
+	req.request.signal = req32.request.signal;
+	err = drm_ioctl_kernel(file, drm_wait_vblank, &req, DRM_UNLOCKED);
 	if (err)
 		return err;
 
-	if (__get_user(req32.reply.type, &request->reply.type)
-	    || __get_user(req32.reply.sequence, &request->reply.sequence)
-	    || __get_user(req32.reply.tval_sec, &request->reply.tval_sec)
-	    || __get_user(req32.reply.tval_usec, &request->reply.tval_usec))
-		return -EFAULT;
-
+	req32.reply.type = req.reply.type;
+	req32.reply.sequence = req.reply.sequence;
+	req32.reply.tval_sec = req.reply.tval_sec;
+	req32.reply.tval_usec = req.reply.tval_usec;
 	if (copy_to_user(argp, &req32, sizeof(req32)))
 		return -EFAULT;
 
 	return 0;
 }
 
-#if defined(CONFIG_X86) || defined(CONFIG_IA64)
+#if defined(CONFIG_X86)
 typedef struct drm_mode_fb_cmd232 {
 	u32 fb_id;
 	u32 width;
@@ -1032,97 +869,90 @@ static int compat_drm_mode_addfb2(struct file *file, unsigned int cmd,
 				  unsigned long arg)
 {
 	struct drm_mode_fb_cmd232 __user *argp = (void __user *)arg;
-	struct drm_mode_fb_cmd232 req32;
-	struct drm_mode_fb_cmd2 __user *req64;
-	int i;
+	struct drm_mode_fb_cmd2 req64;
 	int err;
+	u32 fb_id;
 
-	if (copy_from_user(&req32, argp, sizeof(req32)))
+	if (copy_from_user(&req64, argp,
+			   offsetof(drm_mode_fb_cmd232_t, modifier)))
 		return -EFAULT;
 
-	req64 = compat_alloc_user_space(sizeof(*req64));
-
-	if (!access_ok(VERIFY_WRITE, req64, sizeof(*req64))
-	    || __put_user(req32.width, &req64->width)
-	    || __put_user(req32.height, &req64->height)
-	    || __put_user(req32.pixel_format, &req64->pixel_format)
-	    || __put_user(req32.flags, &req64->flags))
+	if (copy_from_user(&req64.modifier, &argp->modifier,
+			   sizeof(req64.modifier)))
 		return -EFAULT;
 
-	for (i = 0; i < 4; i++) {
-		if (__put_user(req32.handles[i], &req64->handles[i]))
-			return -EFAULT;
-		if (__put_user(req32.pitches[i], &req64->pitches[i]))
-			return -EFAULT;
-		if (__put_user(req32.offsets[i], &req64->offsets[i]))
-			return -EFAULT;
-		if (__put_user(req32.modifier[i], &req64->modifier[i]))
-			return -EFAULT;
-	}
-
-	err = drm_ioctl(file, DRM_IOCTL_MODE_ADDFB2, (unsigned long)req64);
+	err = drm_ioctl_kernel(file, drm_mode_addfb2, &req64,
+				DRM_CONTROL_ALLOW|DRM_UNLOCKED);
 	if (err)
 		return err;
 
-	if (__get_user(req32.fb_id, &req64->fb_id))
-		return -EFAULT;
-
-	if (copy_to_user(argp, &req32, sizeof(req32)))
+	fb_id = argp->fb_id;
+	if (put_user(req64.fb_id, &fb_id))
 		return -EFAULT;
 
 	return 0;
 }
 #endif
 
-static drm_ioctl_compat_t *drm_compat_ioctls[] = {
-	[DRM_IOCTL_NR(DRM_IOCTL_VERSION32)] = compat_drm_version,
-	[DRM_IOCTL_NR(DRM_IOCTL_GET_UNIQUE32)] = compat_drm_getunique,
-	[DRM_IOCTL_NR(DRM_IOCTL_GET_MAP32)] = compat_drm_getmap,
-	[DRM_IOCTL_NR(DRM_IOCTL_GET_CLIENT32)] = compat_drm_getclient,
-	[DRM_IOCTL_NR(DRM_IOCTL_GET_STATS32)] = compat_drm_getstats,
-	[DRM_IOCTL_NR(DRM_IOCTL_SET_UNIQUE32)] = compat_drm_setunique,
-	[DRM_IOCTL_NR(DRM_IOCTL_ADD_MAP32)] = compat_drm_addmap,
-	[DRM_IOCTL_NR(DRM_IOCTL_ADD_BUFS32)] = compat_drm_addbufs,
-	[DRM_IOCTL_NR(DRM_IOCTL_MARK_BUFS32)] = compat_drm_markbufs,
-	[DRM_IOCTL_NR(DRM_IOCTL_INFO_BUFS32)] = compat_drm_infobufs,
-	[DRM_IOCTL_NR(DRM_IOCTL_MAP_BUFS32)] = compat_drm_mapbufs,
-	[DRM_IOCTL_NR(DRM_IOCTL_FREE_BUFS32)] = compat_drm_freebufs,
-	[DRM_IOCTL_NR(DRM_IOCTL_RM_MAP32)] = compat_drm_rmmap,
-	[DRM_IOCTL_NR(DRM_IOCTL_SET_SAREA_CTX32)] = compat_drm_setsareactx,
-	[DRM_IOCTL_NR(DRM_IOCTL_GET_SAREA_CTX32)] = compat_drm_getsareactx,
-	[DRM_IOCTL_NR(DRM_IOCTL_RES_CTX32)] = compat_drm_resctx,
-	[DRM_IOCTL_NR(DRM_IOCTL_DMA32)] = compat_drm_dma,
+static struct {
+	drm_ioctl_compat_t *fn;
+	char *name;
+} drm_compat_ioctls[] = {
+#define DRM_IOCTL32_DEF(n, f) [DRM_IOCTL_NR(n##32)] = {.fn = f, .name = #n}
+	DRM_IOCTL32_DEF(DRM_IOCTL_VERSION, compat_drm_version),
+	DRM_IOCTL32_DEF(DRM_IOCTL_GET_UNIQUE, compat_drm_getunique),
+	DRM_IOCTL32_DEF(DRM_IOCTL_GET_MAP, compat_drm_getmap),
+	DRM_IOCTL32_DEF(DRM_IOCTL_GET_CLIENT, compat_drm_getclient),
+	DRM_IOCTL32_DEF(DRM_IOCTL_GET_STATS, compat_drm_getstats),
+	DRM_IOCTL32_DEF(DRM_IOCTL_SET_UNIQUE, compat_drm_setunique),
+	DRM_IOCTL32_DEF(DRM_IOCTL_ADD_MAP, compat_drm_addmap),
+	DRM_IOCTL32_DEF(DRM_IOCTL_ADD_BUFS, compat_drm_addbufs),
+	DRM_IOCTL32_DEF(DRM_IOCTL_MARK_BUFS, compat_drm_markbufs),
+	DRM_IOCTL32_DEF(DRM_IOCTL_INFO_BUFS, compat_drm_infobufs),
+	DRM_IOCTL32_DEF(DRM_IOCTL_MAP_BUFS, compat_drm_mapbufs),
+	DRM_IOCTL32_DEF(DRM_IOCTL_FREE_BUFS, compat_drm_freebufs),
+	DRM_IOCTL32_DEF(DRM_IOCTL_RM_MAP, compat_drm_rmmap),
+	DRM_IOCTL32_DEF(DRM_IOCTL_SET_SAREA_CTX, compat_drm_setsareactx),
+	DRM_IOCTL32_DEF(DRM_IOCTL_GET_SAREA_CTX, compat_drm_getsareactx),
+	DRM_IOCTL32_DEF(DRM_IOCTL_RES_CTX, compat_drm_resctx),
+	DRM_IOCTL32_DEF(DRM_IOCTL_DMA, compat_drm_dma),
 #if IS_ENABLED(CONFIG_AGP)
-	[DRM_IOCTL_NR(DRM_IOCTL_AGP_ENABLE32)] = compat_drm_agp_enable,
-	[DRM_IOCTL_NR(DRM_IOCTL_AGP_INFO32)] = compat_drm_agp_info,
-	[DRM_IOCTL_NR(DRM_IOCTL_AGP_ALLOC32)] = compat_drm_agp_alloc,
-	[DRM_IOCTL_NR(DRM_IOCTL_AGP_FREE32)] = compat_drm_agp_free,
-	[DRM_IOCTL_NR(DRM_IOCTL_AGP_BIND32)] = compat_drm_agp_bind,
-	[DRM_IOCTL_NR(DRM_IOCTL_AGP_UNBIND32)] = compat_drm_agp_unbind,
+	DRM_IOCTL32_DEF(DRM_IOCTL_AGP_ENABLE, compat_drm_agp_enable),
+	DRM_IOCTL32_DEF(DRM_IOCTL_AGP_INFO, compat_drm_agp_info),
+	DRM_IOCTL32_DEF(DRM_IOCTL_AGP_ALLOC, compat_drm_agp_alloc),
+	DRM_IOCTL32_DEF(DRM_IOCTL_AGP_FREE, compat_drm_agp_free),
+	DRM_IOCTL32_DEF(DRM_IOCTL_AGP_BIND, compat_drm_agp_bind),
+	DRM_IOCTL32_DEF(DRM_IOCTL_AGP_UNBIND, compat_drm_agp_unbind),
 #endif
-	[DRM_IOCTL_NR(DRM_IOCTL_SG_ALLOC32)] = compat_drm_sg_alloc,
-	[DRM_IOCTL_NR(DRM_IOCTL_SG_FREE32)] = compat_drm_sg_free,
+	DRM_IOCTL32_DEF(DRM_IOCTL_SG_ALLOC, compat_drm_sg_alloc),
+	DRM_IOCTL32_DEF(DRM_IOCTL_SG_FREE, compat_drm_sg_free),
 #if defined(CONFIG_X86) || defined(CONFIG_IA64)
-	[DRM_IOCTL_NR(DRM_IOCTL_UPDATE_DRAW32)] = compat_drm_update_draw,
+	DRM_IOCTL32_DEF(DRM_IOCTL_UPDATE_DRAW, compat_drm_update_draw),
 #endif
-	[DRM_IOCTL_NR(DRM_IOCTL_WAIT_VBLANK32)] = compat_drm_wait_vblank,
+	DRM_IOCTL32_DEF(DRM_IOCTL_WAIT_VBLANK, compat_drm_wait_vblank),
 #if defined(CONFIG_X86) || defined(CONFIG_IA64)
-	[DRM_IOCTL_NR(DRM_IOCTL_MODE_ADDFB232)] = compat_drm_mode_addfb2,
+	DRM_IOCTL32_DEF(DRM_IOCTL_MODE_ADDFB2, compat_drm_mode_addfb2),
 #endif
 };
 
 /**
- * Called whenever a 32-bit process running under a 64-bit kernel
- * performs an ioctl on /dev/drm.
+ * drm_compat_ioctl - 32bit IOCTL compatibility handler for DRM drivers
+ * @filp: file this ioctl is called on
+ * @cmd: ioctl cmd number
+ * @arg: user argument
  *
- * \param file_priv DRM file private.
- * \param cmd command.
- * \param arg user argument.
- * \return zero on success or negative number on failure.
+ * Compatibility handler for 32 bit userspace running on 64 kernels. All actual
+ * IOCTL handling is forwarded to drm_ioctl(), while marshalling structures as
+ * appropriate. Note that this only handles DRM core IOCTLs, if the driver has
+ * botched IOCTL itself, it must handle those by wrapping this function.
+ *
+ * Returns:
+ * Zero on success, negative error code on failure.
  */
 long drm_compat_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 {
 	unsigned int nr = DRM_IOCTL_NR(cmd);
+	struct drm_file *file_priv = filp->private_data;
 	drm_ioctl_compat_t *fn;
 	int ret;
 
@@ -1133,14 +963,19 @@ long drm_compat_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 	if (nr >= ARRAY_SIZE(drm_compat_ioctls))
 		return drm_ioctl(filp, cmd, arg);
 
-	fn = drm_compat_ioctls[nr];
+	fn = drm_compat_ioctls[nr].fn;
+	if (!fn)
+		return drm_ioctl(filp, cmd, arg);
 
-	if (fn != NULL)
-		ret = (*fn) (filp, cmd, arg);
-	else
-		ret = drm_ioctl(filp, cmd, arg);
-
+	DRM_DEBUG("pid=%d, dev=0x%lx, auth=%d, %s\n",
+		  task_pid_nr(current),
+		  (long)old_encode_dev(file_priv->minor->kdev->devt),
+		  file_priv->authenticated,
+		  drm_compat_ioctls[nr].name);
+	ret = (*fn)(filp, cmd, arg);
+	if (ret)
+		DRM_DEBUG("ret = %d\n", ret);
 	return ret;
 }
-
 EXPORT_SYMBOL(drm_compat_ioctl);
+#endif

--- a/drm/drm_ioctl.c
+++ b/drm/drm_ioctl.c
@@ -95,7 +95,7 @@
  * broken.
  */
 
-static int drm_version(struct drm_device *dev, void *data,
+int drm_version(struct drm_device *dev, void *data,
 		       struct drm_file *file_priv);
 
 /*
@@ -109,7 +109,7 @@ static int drm_version(struct drm_device *dev, void *data,
  *
  * Copies the bus id from drm_device::unique into user space.
  */
-static int drm_getunique(struct drm_device *dev, void *data,
+int drm_getunique(struct drm_device *dev, void *data,
 		  struct drm_file *file_priv)
 {
 	struct drm_unique *u = data;
@@ -170,7 +170,7 @@ static int drm_set_busid(struct drm_device *dev, struct drm_file *file_priv)
  * Searches for the client with the specified index and copies its information
  * into userspace
  */
-static int drm_getclient(struct drm_device *dev, void *data,
+int drm_getclient(struct drm_device *dev, void *data,
 		  struct drm_file *file_priv)
 {
 	struct drm_client *client = data;
@@ -447,7 +447,7 @@ static int drm_copy_field(char __user *buf, size_t *buf_len, const char *value)
  *
  * Fills in the version information in \p arg.
  */
-static int drm_version(struct drm_device *dev, void *data,
+int drm_version(struct drm_device *dev, void *data,
 		       struct drm_file *file_priv)
 {
 	struct drm_version *version = data;
@@ -642,6 +642,33 @@ static const struct drm_ioctl_desc drm_ioctls[] = {
 
 #define DRM_CORE_IOCTL_COUNT	ARRAY_SIZE( drm_ioctls )
 
+
+long drm_ioctl_kernel(struct file *file, drm_ioctl_t *func, void *kdata,
+		      u32 flags)
+{
+	struct drm_file *file_priv = file->private_data;
+	struct drm_device *dev = file_priv->minor->dev;
+	int retcode;
+
+	if (drm_device_is_unplugged(dev))
+		return -ENODEV;
+
+	retcode = drm_ioctl_permit(flags, file_priv);
+	if (unlikely(retcode))
+		return retcode;
+
+	/* Enforce sane locking for modern driver ioctls. */
+	if (!drm_core_check_feature(dev, DRIVER_LEGACY) ||
+	    (flags & DRM_UNLOCKED))
+		retcode = func(dev, kdata, file_priv);
+	else {
+		mutex_lock(&drm_global_mutex);
+		retcode = func(dev, kdata, file_priv);
+		mutex_unlock(&drm_global_mutex);
+	}
+	return retcode;
+}
+
 /**
  * drm_ioctl - ioctl callback implementation for DRM drivers
  * @filp: file this ioctl is called on
@@ -709,10 +736,6 @@ long drm_ioctl(struct file *filp,
 		goto err_i1;
 	}
 
-	retcode = drm_ioctl_permit(ioctl->flags, file_priv);
-	if (unlikely(retcode))
-		goto err_i1;
-
 	if (ksize <= sizeof(stack_kdata)) {
 		kdata = stack_kdata;
 	} else {
@@ -731,17 +754,7 @@ long drm_ioctl(struct file *filp,
 	if (ksize > in_size)
 		memset(kdata + in_size, 0, ksize - in_size);
 
-	/* Enforce sane locking for modern driver ioctls. Core ioctls are
-	 * too messy still. */
-	if ((!drm_core_check_feature(dev, DRIVER_LEGACY) && is_driver_ioctl) ||
-	    (ioctl->flags & DRM_UNLOCKED))
-		retcode = func(dev, kdata, file_priv);
-	else {
-		mutex_lock(&drm_global_mutex);
-		retcode = func(dev, kdata, file_priv);
-		mutex_unlock(&drm_global_mutex);
-	}
-
+	retcode = drm_ioctl_kernel(filp, func, kdata, ioctl->flags);
 	if (copy_to_user((void __user *)arg, kdata, out_size) != 0)
 		retcode = -EFAULT;
 

--- a/drm/drm_os_config.h
+++ b/drm/drm_os_config.h
@@ -2,6 +2,7 @@
 #define DRM_OS_CONFIG_H_ 
 
 #define CONFIG_DEBUG_FS 1
+#define COMPAT_FREEBSD32 1
 #ifdef COMPAT_FREEBSD32
 #define CONFIG_COMPAT 1
 #endif
@@ -27,10 +28,6 @@
 #define	CONFIG_ACPI_SLEEP 1 
 #define	CONFIG_DRM_I915_KMS 1
 #undef	CONFIG_INTEL_IOMMU
-#endif
-
-#ifdef COMPAT_FREEBSD32
-#define	CONFIG_COMPAT
 #endif
 
 #define	CONFIG_AGP	1

--- a/i915/i915_drv.c
+++ b/i915/i915_drv.c
@@ -230,7 +230,7 @@ static void intel_detect_pch(struct drm_device *dev)
 	pci_dev_put(pch);
 }
 
-static int i915_getparam(struct drm_device *dev, void *data,
+int i915_getparam(struct drm_device *dev, void *data,
 			 struct drm_file *file_priv)
 {
 	struct drm_i915_private *dev_priv = to_i915(dev);

--- a/i915/i915_ioc32.c
+++ b/i915/i915_ioc32.c
@@ -46,24 +46,24 @@ struct drm_i915_getparam32 {
 	u32 value;
 };
 
+extern int i915_getparam(struct drm_device *dev, void *data,
+			 struct drm_file *file_priv);
+
 static int compat_i915_getparam(struct file *file, unsigned int cmd,
 				unsigned long arg)
 {
+	drm_i915_getparam_t __user *request = (void __user *)arg;
 	struct drm_i915_getparam32 req32;
-	drm_i915_getparam_t __user *request;
 
-	if (copy_from_user(&req32, (void __user *)arg, sizeof(req32)))
+	if (copy_from_user(&req32, request, sizeof(req32)))
 		return -EFAULT;
 
-	request = compat_alloc_user_space(sizeof(*request));
-	if (!access_ok(VERIFY_WRITE, request, sizeof(*request))
-	    || __put_user(req32.param, &request->param)
-	    || __put_user((void __user *)(unsigned long)req32.value,
-			  &request->value))
+	if (put_user(req32.param, &request->param)
+	    || put_user(req32.value, &request->value))
 		return -EFAULT;
 
-	return drm_ioctl(file, DRM_IOCTL_I915_GETPARAM,
-			 (unsigned long)request);
+	return drm_ioctl_kernel(file, i915_getparam,
+			 request, DRM_AUTH|DRM_RENDER_ALLOW);
 }
 
 static drm_ioctl_compat_t *i915_compat_ioctls[] = {

--- a/i915/i915_ioc32.c
+++ b/i915/i915_ioc32.c
@@ -54,16 +54,16 @@ static int compat_i915_getparam(struct file *file, unsigned int cmd,
 {
 	drm_i915_getparam_t __user *request = (void __user *)arg;
 	struct drm_i915_getparam32 req32;
+	struct drm_i915_getparam req;
 
 	if (copy_from_user(&req32, request, sizeof(req32)))
 		return -EFAULT;
 
-	if (put_user(req32.param, &request->param)
-	    || put_user(req32.value, &request->value))
-		return -EFAULT;
+	req.param = req32.param;
+	req.value = (void *)(uintptr_t)req32.value;
 
 	return drm_ioctl_kernel(file, i915_getparam,
-			 request, DRM_AUTH|DRM_RENDER_ALLOW);
+			 &req, DRM_AUTH|DRM_RENDER_ALLOW);
 }
 
 static drm_ioctl_compat_t *i915_compat_ioctls[] = {

--- a/include/drm/drmP.h
+++ b/include/drm/drmP.h
@@ -137,6 +137,7 @@
 #include <drm/drm_mem_util.h>
 #include <drm/drm_mm.h>
 #include <drm/drm_os_freebsd.h>
+#include <drm/drm_ioctl.h>
 #include <uapi/drm/drm_sarea.h>
 #include <drm/drm_vma_manager.h>
 #include <linux/atomic.h>
@@ -387,48 +388,6 @@ void drm_printk(const char *level, unsigned int category,
 /*@{*/
 
 #define DRM_IF_VERSION(maj, min) (maj << 16 | min)
-
-/**
- * Ioctl function type.
- *
- * \param inode device inode.
- * \param file_priv DRM file private pointer.
- * \param cmd command.
- * \param arg argument.
- */
-typedef int drm_ioctl_t(struct drm_device *dev, void *data,
-			struct drm_file *file_priv);
-
-typedef int drm_ioctl_compat_t(struct file *filp, unsigned int cmd,
-			       unsigned long arg);
-
-#define DRM_IOCTL_NR(n)                ((n) & 0xff)
-
-
-#define DRM_MAJOR       226
-
-#define DRM_AUTH	0x1
-#define	DRM_MASTER	0x2
-#define DRM_ROOT_ONLY	0x4
-#define DRM_CONTROL_ALLOW 0x8
-#define DRM_UNLOCKED	0x10
-#define DRM_RENDER_ALLOW 0x20
-
-struct drm_ioctl_desc {
-	unsigned long cmd;
-	int flags;
-	drm_ioctl_t *func;
-	unsigned int cmd_drv;
-	char *name;
-};
-
-/**
- * Creates a driver or general drm_ioctl_desc array entry for the given
- * ioctl, for use by drm_ioctl().
- */
-
-#define DRM_IOCTL_DEF_DRV(ioctl, _func, _flags)			\
-	[DRM_IOCTL_NR(DRM_##ioctl)] = {.cmd = DRM_IOCTL_##ioctl, .func = _func, .flags = _flags, .cmd_drv = DRM_IOCTL_##ioctl, .name = #ioctl }
 
 /* Event queued up for userspace to read */
 struct drm_pending_event {
@@ -1047,12 +1006,6 @@ static inline bool drm_is_primary_client(const struct drm_file *file_priv)
 /*@{*/
 
 				/* Driver support (drm_drv.h) */
-extern int drm_ioctl_permit(u32 flags, struct drm_file *file_priv);
-extern long drm_ioctl(struct file *filp,
-		      unsigned int cmd, unsigned long arg);
-extern long drm_compat_ioctl(struct file *filp,
-			     unsigned int cmd, unsigned long arg);
-extern bool drm_ioctl_flags(unsigned int nr, unsigned int *flags);
 
 /* File Operations (drm_fops.c) */
 int drm_open(struct inode *inode, struct file *filp);
@@ -1072,12 +1025,6 @@ void drm_event_cancel_free(struct drm_device *dev,
 			   struct drm_pending_event *p);
 void drm_send_event_locked(struct drm_device *dev, struct drm_pending_event *e);
 void drm_send_event(struct drm_device *dev, struct drm_pending_event *e);
-
-/* Misc. IOCTL support (drm_ioctl.c) */
-int drm_noop(struct drm_device *dev, void *data,
-	     struct drm_file *file_priv);
-int drm_invalid_op(struct drm_device *dev, void *data,
-		   struct drm_file *file_priv);
 
 /* Cache management (drm_cache.c) */
 void drm_clflush_pages(vm_page_t *pages, unsigned long num_pages);


### PR DESCRIPTION
Fixes https://github.com/FreeBSDDesktop/freebsd-base-graphics/issues/166 :)

Requires https://github.com/freebsd/freebsd/commit/10ef676c4bbe7379de1f3687444e4311a7d872e2

Mostly based on importing drm_ioc32.c from current linux.
(They no longer use compat_alloc_user_space.)

Tested: on amdgpu, Wine runs 32-bit Quake II, and Steam under Linuxulator shows the login window instead of segfaulting.

Relevant Linux commits:
- https://github.com/torvalds/linux/commit/7cfdf711ffb02b45a4c84fdc4e7272320ec9fd2e
- https://github.com/torvalds/linux/commit/7f0dfc1625dbaa1360414206d420231b9828701a
- https://github.com/torvalds/linux/commit/5c7640ab625829fd08b7fa0160c6fd188e70b5fe https://github.com/torvalds/linux/commit/17e3dade62d6e95131ceba1535eb8d2e84b2e040 etc.