### PR TITLE
Shorten module names for FreeBSD.

### DIFF
--- a/drivers/gpu/drm/i915/intel_huc.c
+++ b/drivers/gpu/drm/i915/intel_huc.c
@@ -52,9 +52,15 @@
 #define KBL_HUC_FW_MINOR 00
 #define KBL_BLD_NUM 1810
 
+#ifdef __linux__
 #define HUC_FW_PATH(platform, major, minor, bld_num) \
 	"i915/" __stringify(platform) "_huc_ver" __stringify(major) "_" \
 	__stringify(minor) "_" __stringify(bld_num) ".bin"
+#else
+#define HUC_FW_PATH(platform, major, minor, bld_num) \
+	"i915/" __stringify(platform) "_huc_ver" __stringify(major) "_" \
+	__stringify(minor) ".bin"
+#endif
 
 #define I915_SKL_HUC_UCODE HUC_FW_PATH(skl, SKL_HUC_FW_MAJOR, \
 	SKL_HUC_FW_MINOR, SKL_BLD_NUM)


### PR DESCRIPTION
Newly added firmware modules have very long names but FreeBSD module
name cannot be this long.  Work around it by omitting build numbers.