### PR TITLE
Re-add lost ioctl.c fix

### DIFF
--- a/drivers/gpu/drm/drm_ioctl.c
+++ b/drivers/gpu/drm/drm_ioctl.c
@@ -191,10 +191,11 @@ static int drm_getclient(struct drm_device *dev, void *data,
 	 */
 	if (client->idx == 0) {
 		client->auth = file_priv->authenticated;
-		client->pid = task_pid_vnr(current);
 #ifdef __linux__
+		client->pid = task_pid_vnr(current);
 		client->uid = overflowuid;
 #else
+		client->pid = file_priv->pid;
 		client->uid = 0;
 #endif
 		client->magic = 0;


### PR DESCRIPTION
Was complaining about `task_pid_vnr` not existing.

With this, 4.12 compiles and works on AMD Polaris.