### PR TITLE
pull request to resolve issue https://github.com/FreeBSDDesktop/kms-drm/issues/78

### DIFF
--- a/drivers/gpu/drm/ttm/ttm_bo_vm.c
+++ b/drivers/gpu/drm/ttm/ttm_bo_vm.c
@@ -301,8 +301,7 @@ retry:
 				goto retry;
 		} else {
 			if (bo->mem.bus.is_iomem) {
-				pfn = OFF_TO_IDX(bo->mem.bus.base +
-				    bo->mem.bus.offset) + page_offset;
+				pfn = bdev->driver->io_mem_pfn(bo, page_offset);
 				page = PHYS_TO_VM_PAGE(IDX_TO_OFF(pfn));
 			} else {
 				page = ttm->pages[page_offset];


### PR DESCRIPTION
amdgpu uses a different function to resolve the pfn than radeon did. The FreeBSD specific code had copied the radeon code instead of using the structure's function pointer.