### PR TITLE
Reject inappropriate ioctls with EINVAL

### DIFF
--- a/drivers/gpu/drm/drm_ioctl.c
+++ b/drivers/gpu/drm/drm_ioctl.c
@@ -799,6 +799,13 @@ long drm_ioctl(struct file *filp,
 	if (drm_dev_is_unplugged(dev))
 		return -ENODEV;
 
+#ifndef __linux__
+	if (IOCGROUP(cmd) != DRM_IOCTL_BASE) {
+		DRM_DEBUG("bad ioctl group 0x%x\n", (int)IOCGROUP(cmd));
+		return -EINVAL;
+	}
+#endif
+
 	is_driver_ioctl = nr >= DRM_COMMAND_BASE && nr < DRM_COMMAND_END;
 
 	if (is_driver_ioctl) {


### PR DESCRIPTION
The following is a copy from the original issue (https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=231221):

Overview
--

The `drm_ioctl` function (drivers/gpu/drm/drm_ioctl.c#783) uses `DRM_IOCTL_NR(cmd)` to determine which ioctl should be called, but it does not check if cmd is actually a valid ioctl for the driver.

Steps to Reproduce
--

I was trying to determine if a given file descriptor belongs to a drm or an input device, for which I was using two ioctl requests: `IOCGVERSION` and `DRM_IOCTL_VERSION`. I expected requesting `IOCGVERSION` from a drm device would return `EINVAL`, but it returns `0.` This simple PoC demonstrates this behavior:

```c
#include <errno.h>
#include <fcntl.h>
#include <stdio.h>
#include <string.h>
#include <sys/ioctl.h>
#include <dev/evdev/input.h>

int main(int argc, char** argv) {
        int fd = open("/dev/drm/0", O_RDONLY);
        int dummy = -1;
        int ret = ioctl(fd, EVIOCGVERSION, &dummy);
        printf("ret=%d, err=%s, dummy=%d\n", ret, strerror(errno), dummy);
}
```

Actual Results
--

The above program shows that requesting `EVIOCGVERSION` from a drm device succeeds:

```
[0x00 ~]$ cc test2.c -o test2
[0x00 ~]$ ./test2
ret=0, err=No error: 0, dummy=0
```

Expected Results
--

The expected result would be a failed ioctl call:

```
[0x00 ~]$ ./test2
ret=-1, err=Invalid argument, dummy=-1
```

Patch
--

This problem exists because `DRM_IOCTL_NR(EVIOCGVERSION) = 1`, therefore `drm_ioctl` will use `DRM_IOCTL_GET_UNIQUE` (because `DRM_IOCTL_NR(DRM_IOCTL_GET_UNIQUE)` is also 1). The drm_ioctl.c in base compares `IOCGROUP(cmd)` with `DRM_IOCTL_BASE`, and returns `-EINVAL` if they differ. I have copied that comparison to the patch attached.