### PR TITLE
Build radeon+amdgpu on aarch64

### DIFF
--- a/amd/Makefile
+++ b/amd/Makefile
@@ -1,12 +1,11 @@
 # $FreeBSD$
 
-.if ${MACHINE_CPUARCH} == "amd64" 
+.if ${MACHINE_CPUARCH} == "amd64" || ${MACHINE_CPUARCH} == "aarch64" || ${MACHINE_ARCH} == "powerpc64"
 _amdgpu=	amdgpu
-# _amdkfd=	amdkfd
 .endif
 
-.if ${MACHINE_ARCH} == "powerpc64"
-_amdgpu=	amdgpu
+.if ${MACHINE_CPUARCH} == "amd64"
+# _amdkfd=	amdkfd
 .endif
 
 SUBDIR=	${_amdgpu} \

--- a/amd/amdgpu/Makefile
+++ b/amd/amdgpu/Makefile
@@ -201,7 +201,7 @@ SRCS+=	amdgpu_afmt.c \
 	vega10_ih.c \
 	vi.c
 
-.if ${MACHINE_CPUARCH} == "amd64" || ${MACHINE_CPUARCH} == "i386"
+.if ${MACHINE_CPUARCH} == "amd64" || ${MACHINE_CPUARCH} == "i386" || ${MACHINE_CPUARCH} == "aarch64"
 SRCS+=	amdgpu_acpi.c \
 	amdgpu_atpx_handler.c
 .endif

--- a/amd/amdgpu/Makefile
+++ b/amd/amdgpu/Makefile
@@ -5,6 +5,10 @@ DRM= ${.CURDIR:H:H}/drivers/gpu/drm
 
 KMOD=	amdgpu
 
+.if ${MACHINE_CPUARCH} == "amd64"
+_dml=	${SRCDIR}/display/dc/dml
+.endif
+
 .PATH:	${SRCDIR}/acp \
 	${SRCDIR}/amdgpu \
 	${SRCDIR}/amdkfd \
@@ -25,7 +29,7 @@ KMOD=	amdgpu
 	${SRCDIR}/display/dc/dce120 \
 	${SRCDIR}/display/dc/dce80 \
 	${SRCDIR}/display/dc/dcn10 \
-	${SRCDIR}/display/dc/dml \
+	${_dml} \
 	${SRCDIR}/display/dc/gpio \
 	${SRCDIR}/display/dc/gpio/dce110 \
 	${SRCDIR}/display/dc/gpio/dce120 \
@@ -196,10 +200,14 @@ SRCS+=	amdgpu_afmt.c \
 	vcn_v1_0.c \
 	vega10_ih.c \
 	vi.c
+
+.if ${MACHINE_CPUARCH} == "amd64" || ${MACHINE_CPUARCH} == "i386"
+SRCS+=	amdgpu_acpi.c \
+	amdgpu_atpx_handler.c
+.endif
+
 .if ${MACHINE_CPUARCH} == "amd64"
-SRCS+= amdgpu_acpi.c \
-	amdgpu_atpx_handler.c \
-	dcn10_clk_mgr.c \
+SRCS+=	dcn10_clk_mgr.c \
 	dcn10_cm_common.c \
 	dcn10_dpp.c \
 	dcn10_dpp_cm.c \
@@ -297,11 +305,6 @@ SRCS+=	amdgpu_dm.c \
 	dce_scl_filters.c \
 	dce_stream_encoder.c \
 	dce_transform.c \
-	dcn_calc_math.c \
-	display_mode_lib.c \
-	display_rq_dlg_helpers.c \
-	dml1_display_rq_dlg_calc.c \
-	dml_common_defs.c \
 	engine_base.c \
 	fixpt31_32.c \
 	freesync.c \
@@ -348,6 +351,14 @@ SRCS+=	amdgpu_dm.c \
 	vector.c \
 	virtual_link_encoder.c \
 	virtual_stream_encoder.c
+
+.if ${MACHINE_CPUARCH} == "amd64"
+SRCS+=	display_mode_lib.c \
+	dcn_calc_math.c \
+	display_rq_dlg_helpers.c \
+	dml_common_defs.c \
+	dml1_display_rq_dlg_calc.c
+.endif
 
 # lib
 SRCS+=	chash.c
@@ -435,21 +446,8 @@ SRCS+=	device_if.h vnode_if.h bus_if.h pci_if.h device_if.h iicbus_if.h opt_drm.
 
 .include <bsd.kmod.mk>
 
-CFLAGS.gcc+= -Wno-redundant-decls -Wno-cast-qual -Wno-unused-but-set-variable
-.if ${MACHINE_CPUARCH} == "powerpc"
-CFLAGS.dcn_calcs.c= -maltivec -mhard-float -mfull-toc
-CFLAGS.dcn_calc_auto.c= -maltivec -mhard-float -mfull-toc
-CFLAGS.dcn_calc_math.c= -maltivec -mhard-float -mfull-toc
+CFLAGS.gcc+= -Wno-redundant-decls -Wno-unused-but-set-variable
 
-CFLAGS.display_mode_vba.c= -maltivec -mhard-float -mfull-toc
-CFLAGS.display_mode_lib.c= -maltivec -mhard-float -mfull-toc
-CFLAGS.display_pipe_clocks.c= -maltivec -mhard-float -mfull-toc
-CFLAGS.display_rq_dlg_calc.c= -maltivec -mhard-float -mfull-toc
-CFLAGS.dml1_display_rq_dlg_calc.c= -maltivec -mhard-float -mfull-toc
-CFLAGS.display_rq_dlg_helpers.c= -maltivec -mhard-float -mfull-toc
-CFLAGS.soc_bounding_box.c= -maltivec -mhard-float -mfull-toc
-CFLAGS.dml_common_defs.c= -maltivec -mhard-float -mfull-toc
-.else
 CFLAGS.dcn_calcs.c= -msse -mstack-alignment=4
 CFLAGS.dcn_calc_auto.c= -msse -mstack-alignment=4
 CFLAGS.dcn_calc_math.c= -msse -mstack-alignment=4 -Wno-tautological-compare
@@ -462,8 +460,6 @@ CFLAGS.soc_bounding_box.c= -msse -mstack-alignment=4
 CFLAGS.dml_common_defs.c= -msse -mstack-alignment=4
 
 CWARNFLAGS+=	-Wno-pointer-arith -Wno-format -Wno-cast-qual
-.endif
-CWARNFLAGS+=	-Wno-pointer-arith -Wno-format
 CWARNFLAGS+=	-Wno-pointer-sign ${CWARNFLAGS.${.IMPSRC:T}}
 CWARNFLAGS+=	-Wno-expansion-to-defined
 

--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_freebsd.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_freebsd.c
@@ -9,7 +9,9 @@ __FBSDID("$FreeBSD$");
 
 MODULE_DEPEND(amdgpu, drmn, 2, 2, 2);
 MODULE_DEPEND(amdgpu, ttm, 1, 1, 1);
+#ifdef CONFIG_AGP
 MODULE_DEPEND(amdgpu, agp, 1, 1, 1);
+#endif
 MODULE_DEPEND(amdgpu, linuxkpi, 1, 1, 1);
 MODULE_DEPEND(amdgpu, linuxkpi_gplv2, 1, 1, 1);
 MODULE_DEPEND(amdgpu, firmware, 1, 1, 1);

--- a/drivers/gpu/drm/drm_os_config.h
+++ b/drivers/gpu/drm/drm_os_config.h
@@ -45,13 +45,21 @@
 #undef CONFIG_AS_MOVNTDQA
 #endif
 
-
+#ifdef __aarch64__
+#define CONFIG_ARM64 1
+#define CONFIG_PCI 1
+#define CONFIG_ACPI 1
+#undef CONFIG_ACPI_SLEEP
+#undef CONFIG_DRM_I915_KMS
+#undef CONFIG_INTEL_IOMMU
+#undef CONFIG_AS_MOVNTDQA
+#endif
 
 #ifdef _KERNEL
 #define	__KERNEL__
 #endif
 
-#if !defined(__powerpc__)
+#if !defined(__powerpc__) && !defined(__aarch64__)
 #define	CONFIG_AGP	1
 #endif
 

--- a/drivers/gpu/drm/drm_os_freebsd.c
+++ b/drivers/gpu/drm/drm_os_freebsd.c
@@ -328,7 +328,9 @@ static moduledata_t drm_mod = {
 
 DECLARE_MODULE(drmn, drm_mod, SI_SUB_DRIVERS, SI_ORDER_FIRST);
 MODULE_VERSION(drmn, 2);
+#ifdef CONFIG_AGP
 MODULE_DEPEND(drmn, agp, 1, 1, 1);
+#endif
 MODULE_DEPEND(drmn, pci, 1, 1, 1);
 MODULE_DEPEND(drmn, mem, 1, 1, 1);
 MODULE_DEPEND(drmn, linuxkpi, 1, 1, 1);

--- a/drivers/gpu/drm/radeon/radeon_freebsd.c
+++ b/drivers/gpu/drm/radeon/radeon_freebsd.c
@@ -9,7 +9,9 @@ __FBSDID("$FreeBSD$");
 
 MODULE_DEPEND(radeonkms, drmn, 2, 2, 2);
 MODULE_DEPEND(radeonkms, ttm, 1, 1, 1);
+#ifdef CONFIG_AGP
 MODULE_DEPEND(radeonkms, agp, 1, 1, 1);
+#endif
 MODULE_DEPEND(radeonkms, linuxkpi, 1, 1, 1);
 MODULE_DEPEND(radeonkms, linuxkpi_gplv2, 1, 1, 1);
 MODULE_DEPEND(radeonkms, firmware, 1, 1, 1);

--- a/drivers/gpu/drm/ttm/ttm_module.c
+++ b/drivers/gpu/drm/ttm/ttm_module.c
@@ -104,7 +104,9 @@ MODULE_LICENSE("GPL and additional rights");
 #else
 LKPI_DRIVER_MODULE(ttm, ttm_init, ttm_exit);
 MODULE_VERSION(ttm, 1);
+#ifdef CONFIG_AGP
 MODULE_DEPEND(ttm, agp, 1, 1, 1);
+#endif
 MODULE_DEPEND(ttm, drmn, 2, 2, 2);
 MODULE_DEPEND(ttm, linuxkpi, 1, 1, 1);
 MODULE_DEPEND(ttm, linuxkpi_gplv2, 1, 1, 1);

--- a/drm/Makefile
+++ b/drm/Makefile
@@ -6,7 +6,6 @@ SRCDIR=	${.CURDIR:H}/drivers/gpu/drm
 
 KMOD=	drm
 SRCS=	ati_pcigart.c \
-	drm_agpsupport.c \
 	drm_atomic.c \
 	drm_atomic_helper.c \
 	drm_atomic_state_helper.c \
@@ -85,6 +84,10 @@ SRCS=	ati_pcigart.c \
 	linux_fb.c \
 	tainted_linux_fb.c \
 	linux_hdmi.c
+
+.if ${MACHINE_CPUARCH} == "i386" || ${MACHINE_CPUARCH} == "amd64"
+SRCS+=	drm_agpsupport.c
+.endif
 
 # Skip for now...
 #	drm_dp_cec.c

--- a/include/drm/drm_cache.h
+++ b/include/drm/drm_cache.h
@@ -47,6 +47,24 @@ static inline bool drm_arch_can_wc_memory(void)
 	return false;
 #elif defined(CONFIG_MIPS) && defined(CONFIG_CPU_LOONGSON3)
 	return false;
+#elif defined(CONFIG_ARM) || defined(CONFIG_ARM64)
+	/*
+	 * The DRM driver stack is designed to work with cache coherent devices
+	 * only, but permits an optimization to be enabled in some cases, where
+	 * for some buffers, both the CPU and the GPU use uncached mappings,
+	 * removing the need for DMA snooping and allocation in the CPU caches.
+	 *
+	 * The use of uncached GPU mappings relies on the correct implementation
+	 * of the PCIe NoSnoop TLP attribute by the platform, otherwise the GPU
+	 * will use cached mappings nonetheless. On x86 platforms, this does not
+	 * seem to matter, as uncached CPU mappings will snoop the caches in any
+	 * case. However, on ARM and arm64, enabling this optimization on a
+	 * platform where NoSnoop is ignored results in loss of coherency, which
+	 * breaks correct operation of the device. Since we have no way of
+	 * detecting whether NoSnoop works or not, just disable this
+	 * optimization entirely for ARM and arm64.
+	 */
+	return false;
 #else
 	return true;
 #endif

--- a/linuxkpi/Makefile
+++ b/linuxkpi/Makefile
@@ -33,7 +33,7 @@ SRCS=	linux_kmod_gplv2.c	\
 SRCS+=	linux_genalloc.c
 .endif
 
-.if ${MACHINE_CPUARCH} == "amd64" || ${MACHINE_CPUARCH} == "i386"
+.if ${MACHINE_CPUARCH} == "amd64" || ${MACHINE_CPUARCH} == "i386" || ${MACHINE_CPUARCH} == "aarch64"
 SRCS+=	linux_acpi.c	\
 	linux_video.c 	\
 	opt_acpi.h

--- a/linuxkpi/gplv2/include/linux/acpi.h
+++ b/linuxkpi/gplv2/include/linux/acpi.h
@@ -17,7 +17,7 @@
  *
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  */
-#if defined(__i386__) || defined(__amd64__)
+#if defined(__i386__) || defined(__amd64__) || defined(__aarch64__)
 #ifndef _LINUX_GPLV2_ACPI_H_
 #define _LINUX_GPLV2_ACPI_H_
 

--- a/linuxkpi/gplv2/include/linux/io.h
+++ b/linuxkpi/gplv2/include/linux/io.h
@@ -3,7 +3,7 @@
 
 #include_next <linux/io.h>
  
-#if defined(__amd64__) || defined(__i386__) || defined(__powerpc__)
+#if defined(__amd64__) || defined(__i386__) || defined(__aarch64__) || defined(__powerpc__)
 extern int arch_io_reserve_memtype_wc(resource_size_t start, resource_size_t size);
 extern void arch_io_free_memtype_wc(resource_size_t start, resource_size_t size);
 #endif

--- a/linuxkpi/gplv2/include/linux/irq.h
+++ b/linuxkpi/gplv2/include/linux/irq.h
@@ -15,7 +15,7 @@
 
 #include <asm/processor.h>
 
-#if defined(__i386__) || defined(__amd64__) || defined(__powerpc__)
+#if defined(__i386__) || defined(__amd64__) || defined(__aarch64__) || defined(__powerpc__)
 #define NR_IRQS	512 /* XXX need correct value */
 #else
 #error "NR_IRQS not defined"

--- a/linuxkpi/gplv2/src/linux_i2c.c
+++ b/linuxkpi/gplv2/src/linux_i2c.c
@@ -88,7 +88,7 @@ __FBSDID("$FreeBSD$");
 
 #include <linux/idr.h>
 
-#if defined(__i386__) || defined(__amd64__)
+#if defined(__i386__) || defined(__amd64__) || defined(__aarch64__)
 #include <linux/acpi.h>
 #endif
 #include <linux/device.h>
@@ -627,7 +627,7 @@ i2c_check_addr_busy(struct i2c_adapter *adapter, int addr)
 static void i2c_dev_set_name(struct i2c_adapter *adap,
 			     struct i2c_client *client)
 {
-#if defined(__i386__) || defined(__amd64__)
+#if defined(__i386__) || defined(__amd64__) || defined(__aarch64__)
 	struct acpi_device *adev = ACPI_COMPANION(&client->dev);
 
 	if (adev) {

--- a/linuxkpi/gplv2/src/linux_notifier.c
+++ b/linuxkpi/gplv2/src/linux_notifier.c
@@ -11,11 +11,7 @@
 #include <linux/math64.h>
 #include <linux/kernel.h>
 
-#if defined(__amd64__) || defined(__i386__)
-#define X86
-#endif
-
-#ifdef X86
+#ifdef CONFIG_ACPI
 #include <linux/acpi.h>
 #include <acpi/button.h>
 #endif
@@ -167,7 +163,7 @@ unregister_reboot_notifier(struct notifier_block *nb)
 	return (0);
 }
 
-#ifdef X86
+#ifdef CONFIG_ACPI
 int
 acpi_lid_notifier_register(struct notifier_block *nb)
 {

--- a/radeon/Makefile
+++ b/radeon/Makefile
@@ -112,7 +112,7 @@ SRCS=	atom.c \
 	vce_v1_0.c \
 	vce_v2_0.c
 
-.if ${MACHINE_CPUARCH} == "amd64" || ${MACHINE_CPUARCH} == "i386"
+.if ${MACHINE_CPUARCH} == "amd64" || ${MACHINE_CPUARCH} == "i386" || ${MACHINE_CPUARCH} == "aarch64"
 SRCS+=  opt_acpi.h \
 	radeon_acpi.c \
 	radeon_atpx_handler.c

--- a/ttm/Makefile
+++ b/ttm/Makefile
@@ -5,8 +5,7 @@ SRCDIR=	${.CURDIR:H}/drivers/gpu/drm/ttm
 .PATH:	${SRCDIR}
 
 KMOD=	ttm
-SRCS=	ttm_agp_backend.c \
-	ttm_bo.c \
+SRCS=	ttm_bo.c \
 	ttm_bo_manager.c \
 	ttm_bo_util.c \
 	ttm_bo_vm.c \
@@ -16,6 +15,10 @@ SRCS=	ttm_agp_backend.c \
 	ttm_page_alloc.c \
 	ttm_page_alloc_dma.c \
 	ttm_tt.c
+
+.if ${MACHINE_CPUARCH} == "i386" || ${MACHINE_CPUARCH} == "amd64"
+SRCS+=	ttm_agp_backend.c
+.endif
 
 CLEANFILES+= ${KMOD}.ko.full ${KMOD}.ko.debug
 


### PR DESCRIPTION
![first-ever-freebsd-aarch64-amdgpu](https://user-images.githubusercontent.com/208340/60383512-6bfde600-9a7a-11e9-9faf-b44781cc80e2.jpg)

It works!!

Requires: [D20787](https://reviews.freebsd.org/D20787) and [D20789](https://reviews.freebsd.org/D20789)

Tested on: Marvell MACCHIATObin + AMD Radeon RX 480