### PR TITLE
i915: enable sysfs frequency control

### DIFF
--- a/drivers/gpu/drm/i915/i915_drv.c
+++ b/drivers/gpu/drm/i915/i915_drv.c
@@ -1653,9 +1653,7 @@ static void i915_driver_register(struct drm_i915_private *dev_priv)
 	/* Reveal our presence to userspace */
 	if (drm_dev_register(dev, 0) == 0) {
 		i915_debugfs_register(dev_priv);
-#ifdef __linux__
 		i915_setup_sysfs(dev_priv);
-#endif
 
 #ifdef CONFIG_I915_PERF
 		/* Not yet. i915_perf.c opens a can of worms... */
@@ -1724,9 +1722,7 @@ static void i915_driver_unregister(struct drm_i915_private *dev_priv)
 
 	i915_pmu_unregister(dev_priv);
 
-#ifdef __linux__
 	i915_teardown_sysfs(dev_priv);
-#endif
 	drm_dev_unregister(&dev_priv->drm);
 
 	i915_gem_shrinker_unregister(dev_priv);

--- a/i915/Makefile
+++ b/i915/Makefile
@@ -46,6 +46,7 @@ SRCS=	\
 	i915_suspend.c \
 	i915_sw_fence.c \
 	i915_syncmap.c \
+	i915_sysfs.c \
 	i915_timeline.c \
 	i915_trace_points.c \
 	i915_vgpu.c \


### PR DESCRIPTION
Accessible via `sys.class.drm` sysctls. Fixes #153.

Video demo: https://streamable.com/7x7l7 (most of the power consumption is from vaapi encoding the screencast)

This is a quick fix. Future work: rewrite `sysfs_(create|remove)_files` into base linuxkpi, add `sysfs_(un)?merge_group` and `bin_attribute` stuff to enable all other sysfs things (residency counters, l3 parity whatever that is)