### PR TITLE
Enable Message Signaled Interrupts (MSI)

### DIFF
--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_irq.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_irq.c
@@ -60,8 +60,6 @@
 #endif
 
 #define AMDGPU_WAIT_IDLE_TIMEOUT 200
-#define pci_enable_msi linux_pci_enable_msi
-#define pci_disable_msi linux_pci_disable_msi
 
 /**
  * amdgpu_hotplug_work_func - work handler for display hotplug event
@@ -218,7 +216,7 @@ int amdgpu_irq_init(struct amdgpu_device *adev)
 	adev->irq.msi_enabled = false;
 
 	if (amdgpu_msi_ok(adev)) {
-#ifdef __linux__
+#if defined(__linux__) || defined(pci_enable_msi)
 		int ret = pci_enable_msi(adev->pdev);
 		if (!ret) {
 			adev->irq.msi_enabled = true;
@@ -272,7 +270,7 @@ void amdgpu_irq_fini(struct amdgpu_device *adev)
 	if (adev->irq.installed) {
 		drm_irq_uninstall(adev->ddev);
 		adev->irq.installed = false;
-#ifdef __linux__
+#if defined(__linux__) || defined(pci_disable_msi)
 		if (adev->irq.msi_enabled)
 			pci_disable_msi(adev->pdev);
 #endif

--- a/drivers/gpu/drm/i915/i915_drv.c
+++ b/drivers/gpu/drm/i915/i915_drv.c
@@ -1555,7 +1555,7 @@ static int i915_driver_init_hw(struct drm_i915_private *dev_priv)
 	intel_gt_init_workarounds(dev_priv);
 	i915_gem_load_init_fences(dev_priv);
 
-#ifdef __linux__
+#if defined(__linux__) || defined(pci_enable_msi)
 	/* On the 945G/GM, the chipset reports the MSI capability on the
 	 * integrated graphics even though the support isn't actually there
 	 * according to the published specs.  It doesn't appear to function
@@ -1596,7 +1596,7 @@ static int i915_driver_init_hw(struct drm_i915_private *dev_priv)
 	return 0;
 
 err_msi:
-#ifdef __linux__
+#if defined(__linux__) || defined(pci_disable_msi)
 	if (pdev->msi_enabled)
 		pci_disable_msi(pdev);
 #endif
@@ -1616,11 +1616,15 @@ err_perf:
  */
 static void i915_driver_cleanup_hw(struct drm_i915_private *dev_priv)
 {
-#ifdef __linux__
+#if defined(__linux__) || defined(pci_disable_msi)
 	struct pci_dev *pdev = dev_priv->drm.pdev;
+#endif
 
+#ifdef CONFIG_I915_PERF
 	i915_perf_fini(dev_priv);
+#endif
 
+#if defined(__linux__) || defined(pci_disable_msi)
 	if (pdev->msi_enabled)
 		pci_disable_msi(pdev);
 #endif

--- a/drivers/gpu/drm/radeon/radeon_irq_kms.c
+++ b/drivers/gpu/drm/radeon/radeon_irq_kms.c
@@ -298,7 +298,7 @@ int radeon_irq_kms_init(struct radeon_device *rdev)
 	rdev->msi_enabled = 0;
 
 	if (radeon_msi_ok(rdev)) {
-#ifdef __linux__
+#if defined(__linux__) || defined(pci_enable_msi)
 		int ret = pci_enable_msi(rdev->pdev);
 		if (!ret) {
 			rdev->msi_enabled = 1;
@@ -335,7 +335,7 @@ void radeon_irq_kms_fini(struct radeon_device *rdev)
 	if (rdev->irq.installed) {
 		drm_irq_uninstall(rdev->ddev);
 		rdev->irq.installed = false;
-#ifdef __linux__
+#if defined(__linux__) || defined(pci_disable_msi)
 		if (rdev->msi_enabled)
 			pci_disable_msi(rdev->pdev);
 #endif


### PR DESCRIPTION
This fixes ridiculous interrupt rate on aarch64, was enabled in the legacy in-tree drm port, and is a good idea in general.

Corresponding kernel patch: https://reviews.freebsd.org/D21008 but this shouldn't break the build without it, thanks to `if defined(pci_enable_msi)`.

Tested on amdgpu and i915kms.