### PR TITLE
Fix a use-after-free in vmw_validation_mem_free().

### DIFF
--- a/drivers/gpu/drm/vmwgfx/vmwgfx_validation.c
+++ b/drivers/gpu/drm/vmwgfx/vmwgfx_validation.c
@@ -151,16 +151,15 @@ void *vmw_validation_mem_alloc(struct vmw_validation_context *ctx,
  */
 static void vmw_validation_mem_free(struct vmw_validation_context *ctx)
 {
+	struct page *entry, *next;
 
 #ifdef __linux__
-	struct page *entry, *next;
 	list_for_each_entry_safe(entry, next, &ctx->page_list, lru) {
 		list_del_init(&entry->lru);
 		__free_page(entry);
 	}
 #else
-	struct page *entry;
-	TAILQ_FOREACH(entry, &ctx->bsd_pglist, plinks.q) {
+	TAILQ_FOREACH_SAFE(entry, &ctx->bsd_pglist, plinks.q, next) {
 		vm_page_lock(entry);
 		vm_page_unwire(entry, PQ_NONE);
 		vm_page_unlock(entry);


### PR DESCRIPTION
We were accessing the plinks.q field after the page had been freed.