### PR TITLE
Fix build on FreeBSD-current r351457.

### DIFF
--- a/linuxkpi/gplv2/src/linux_compat.c
+++ b/linuxkpi/gplv2/src/linux_compat.c
@@ -2,6 +2,7 @@
 #include <sys/kernel.h>
 #if defined(__i386__) || defined(__amd64__)
 #include <machine/specialreg.h>
+#include <sys/pcpu.h>
 #include <machine/md_var.h>
 #endif
 #include <linux/bitops.h>


### PR DESCRIPTION
This patch adds the header sys/pcpu.h to linux_compat.c to fix -current build post r351457.