### PR TITLE
DRM_SYSCTL_PRINT fails and has not the lock

### DIFF
--- a/drivers/gpu/drm/drm_sysctl_freebsd.c
+++ b/drivers/gpu/drm/drm_sysctl_freebsd.c
@@ -419,8 +419,8 @@ static int drm_vblank_info DRM_SYSCTL_HANDLER_ARGS
 	int retcode;
 	int i;
 
-	DRM_SYSCTL_PRINT("\ncrtc ref count    last     enabled inmodeset\n");
 	mutex_lock(&dev->struct_mutex);
+	DRM_SYSCTL_PRINT("\ncrtc ref count    last     enabled inmodeset\n");
 	if (dev->vblank == NULL)
 		goto done;
 	for (i = 0 ; i < dev->num_crtcs ; i++) {


### PR DESCRIPTION
fix 'mutex_unlock() system panic' when DRM_SYSCTL_PRINT fails and has not the lock,
reproduced by:

% sysctl -B 1 hw.dri.0.vblank
% sysctl -B 1 hw.dri
% sysctl -B 1 -a