### PR TITLE
Conditionalize (un)wirings of TTM pages.

### DIFF
--- a/drivers/gpu/drm/ttm/ttm_page_alloc.c
+++ b/drivers/gpu/drm/ttm/ttm_page_alloc.c
@@ -316,9 +316,11 @@ static void ttm_pages_put(struct page *pages[], unsigned npages,
 				pr_err("Failed to set %d pages to wb!\n", pages_nr);
 		}
 #ifndef __linux__
+#if __FreeBSD_version < 1300031
 		vm_page_lock(pages[i]);
 		vm_page_unwire(pages[i], PQ_NONE);
 		vm_page_unlock(pages[i]);
+#endif
 #endif
 		__free_pages(pages[i], order);
 	}
@@ -561,9 +563,11 @@ static void ttm_handle_caching_state_failure(struct pglist *pages,
 		list_del(&failed_pages[i]->lru);
 #else
 		TAILQ_REMOVE(pages, failed_pages[i], plinks.q);
+#if __FreeBSD_version < 1300031
 		vm_page_lock(failed_pages[i]);
 		vm_page_unwire(failed_pages[i], PQ_NONE);
 		vm_page_unlock(failed_pages[i]);
+#endif
 #endif
 		__free_page(failed_pages[i]);
 	}
@@ -621,9 +625,11 @@ static int ttm_alloc_new_pages(struct pglist *pages, gfp_t gfp_flags,
 #ifdef __linux__
 		list_add(&p->lru, pages);
 #else
+#if __FreeBSD_version < 1300031
 		vm_page_lock(p);
 		vm_page_wire(p);
 		vm_page_unlock(p);
+#endif
 		TAILQ_INSERT_HEAD(pages, p, plinks.q);
 #endif
 
@@ -887,9 +893,11 @@ static void ttm_put_pages(struct page **pages, unsigned npages, int flags,
 			if (page_count(pages[i]) != 1)
 				pr_err("Erroneous page count. Leaking pages.\n");
 #ifndef __linux__
+#if __FreeBSD_version < 1300031
 			vm_page_lock(pages[i]);
 			vm_page_unwire(pages[i], PQ_NONE);
 			vm_page_unlock(pages[i]);
+#endif
 #endif
 			__free_pages(pages[i], order);
 
@@ -1039,9 +1047,11 @@ static int ttm_get_pages(struct page **pages, unsigned npages, int flags,
 			}
 
 #ifndef __linux__
+#if __FreeBSD_version < 1300031
 			vm_page_lock(p);
 			vm_page_wire(p);
 			vm_page_unlock(p);
+#endif
 #endif
 			/* Swap the pages if we detect consecutive order */
 			if (i > first && pages[i - 1] == p - 1)


### PR DESCRIPTION
After r348743 in the base system, alloc_page() returns a wired page,
so there's no need to manually manipulate the wire count anymore.
Moreover, some planned changes to FreeBSD's VM will change locking rules
for wiring, so let's get ahead of that.