### PR TITLE
Conditionalize (un)wirings of DRM pages.

### DIFF
--- a/drivers/gpu/drm/i915/i915_gem_gtt.c
+++ b/drivers/gpu/drm/i915/i915_gem_gtt.c
@@ -377,6 +377,7 @@ static struct page *vm_alloc_page(struct i915_address_space *vm, gfp_t gfp)
 		return alloc_page(gfp);
 #else
 	{
+#if __FreeBSD_version < 1300031
 		struct page* page = alloc_page(gfp);
 		if (!page)
 			return (NULL);
@@ -384,6 +385,9 @@ static struct page *vm_alloc_page(struct i915_address_space *vm, gfp_t gfp)
 		vm_page_wire(page);
 		vm_page_unlock(page);
 		return (page);
+#else
+		return alloc_page(gfp);
+#endif
 	}
 #endif
 
@@ -409,9 +413,11 @@ static struct page *vm_alloc_page(struct i915_address_space *vm, gfp_t gfp)
 			break;
 
 #ifndef __linux__
+#if __FreeBSD_version < 1300031
 		vm_page_lock(page);
 		vm_page_wire(page);
 		vm_page_unlock(page);
+#endif
 #endif
 		stack.pages[stack.nr++] = page;
 	} while (pagevec_space(&stack));

--- a/drivers/gpu/drm/ttm/ttm_page_alloc.c
+++ b/drivers/gpu/drm/ttm/ttm_page_alloc.c
@@ -264,9 +264,11 @@ static void ttm_pages_put(struct page *pages[], unsigned npages,
 				pr_err("Failed to set %d pages to wb!\n", pages_nr);
 		}
 #ifndef __linux__
+#if __FreeBSD_version < 1300031
 		vm_page_lock(pages[i]);
 		vm_page_unwire(pages[i], PQ_NONE);
 		vm_page_unlock(pages[i]);
+#endif
 #endif
 		__free_pages(pages[i], order);
 	}
@@ -510,9 +512,11 @@ static void ttm_handle_caching_state_failure(struct pglist *pages,
 		list_del(&failed_pages[i]->lru);
 #else
 		TAILQ_REMOVE(pages, failed_pages[i], plinks.q);
+#if __FreeBSD_version < 1300031
 		vm_page_lock(failed_pages[i]);
 		vm_page_unwire(failed_pages[i], PQ_NONE);
 		vm_page_unlock(failed_pages[i]);
+#endif
 #endif
 		__free_page(failed_pages[i]);
 	}
@@ -571,9 +575,11 @@ static int ttm_alloc_new_pages(struct pglist *pages, gfp_t gfp_flags,
 #ifdef __linux__
 		list_add(&p->lru, pages);
 #else
+#if __FreeBSD_version < 1300031
 		vm_page_lock(p);
 		vm_page_wire(p);
 		vm_page_unlock(p);
+#endif
 		TAILQ_INSERT_HEAD(pages, p, plinks.q);
 #endif
 
@@ -840,9 +846,11 @@ static void ttm_put_pages(struct page **pages, unsigned npages, int flags,
 			if (page_count(pages[i]) != 1)
 				pr_err("Erroneous page count. Leaking pages.\n");
 #ifndef __linux__
+#if __FreeBSD_version < 1300031
 			vm_page_lock(pages[i]);
 			vm_page_unwire(pages[i], PQ_NONE);
 			vm_page_unlock(pages[i]);
+#endif
 #endif
 			__free_pages(pages[i], order);
 
@@ -995,9 +1003,11 @@ static int ttm_get_pages(struct page **pages, unsigned npages, int flags,
 			}
 
 #ifndef __linux__
+#if __FreeBSD_version < 1300031
 			vm_page_lock(p);
 			vm_page_wire(p);
 			vm_page_unlock(p);
+#endif
 #endif
 			/* Swap the pages if we detect consecutive order */
 			if (i > first && pages[i - 1] == p - 1)

--- a/drivers/gpu/drm/vmwgfx/vmwgfx_validation.c
+++ b/drivers/gpu/drm/vmwgfx/vmwgfx_validation.c
@@ -126,9 +126,11 @@ void *vmw_validation_mem_alloc(struct vmw_validation_context *ctx,
 #ifdef __linux__
 		list_add_tail(&page->lru, &ctx->page_list);
 #else
+#if __FreeBSD_version < 1300031
 		vm_page_lock(page);
 		vm_page_wire(page);
 		vm_page_unlock(page);
+#endif
 		TAILQ_INSERT_TAIL(&ctx->bsd_pglist, page, plinks.q);
 #endif
 		ctx->page_address = page_address(page);
@@ -160,9 +162,11 @@ static void vmw_validation_mem_free(struct vmw_validation_context *ctx)
 	}
 #else
 	TAILQ_FOREACH_SAFE(entry, &ctx->bsd_pglist, plinks.q, next) {
+#if __FreeBSD_version < 1300031
 		vm_page_lock(entry);
 		vm_page_unwire(entry, PQ_NONE);
 		vm_page_unlock(entry);
+#endif
 		__free_page(entry);
 	}
 #endif


### PR DESCRIPTION
After r348743 in the base system, alloc_page() returns a wired page, so
there's no need to manually manipulate the wire count anymore.
Moreover, some planned changes to FreeBSD's VM will change locking rules
for wiring, so let's get ahead of that.