### PR TITLE
Fix drm-v4.11 on 12.x

### DIFF
--- a/amd/amdgpu/amdgpu_irq.c
+++ b/amd/amdgpu/amdgpu_irq.c
@@ -222,7 +222,7 @@ int amdgpu_irq_init(struct amdgpu_device *adev)
 	adev->irq.msi_enabled = false;
 
 	if (amdgpu_msi_ok(adev)) {
-#ifdef __linux__
+#if defined(__linux__) || defined(pci_enable_msi)
 		int ret = pci_enable_msi(adev->pdev);
 		if (!ret) {
 			adev->irq.msi_enabled = true;
@@ -262,7 +262,7 @@ void amdgpu_irq_fini(struct amdgpu_device *adev)
 	if (adev->irq.installed) {
 		drm_irq_uninstall(adev->ddev);
 		adev->irq.installed = false;
-#ifdef __linux__
+#if defined(__linux__) || defined(pci_disable_msi)
 		if (adev->irq.msi_enabled)
 			pci_disable_msi(adev->pdev);
 #endif

--- a/drm/drm_sysctl.c
+++ b/drm/drm_sysctl.c
@@ -419,8 +419,8 @@ static int drm_vblank_info DRM_SYSCTL_HANDLER_ARGS
 	int retcode;
 	int i;
 
-	DRM_SYSCTL_PRINT("\ncrtc ref count    last     enabled inmodeset\n");
 	mutex_lock(&dev->struct_mutex);
+	DRM_SYSCTL_PRINT("\ncrtc ref count    last     enabled inmodeset\n");
 	if (dev->vblank == NULL)
 		goto done;
 	for (i = 0 ; i < dev->num_crtcs ; i++) {

--- a/i915/i915_drv.c
+++ b/i915/i915_drv.c
@@ -1140,7 +1140,7 @@ static int i915_driver_init_hw(struct drm_i915_private *dev_priv)
 
 	i915_gem_load_init_fences(dev_priv);
 
-#ifdef __linux__
+#if defined(__linux__) || defined(pci_enable_msi)
 	/* On the 945G/GM, the chipset reports the MSI capability on the
 	 * integrated graphics even though the support isn't actually there
 	 * according to the published specs.  It doesn't appear to function
@@ -1176,9 +1176,15 @@ out_ggtt:
  */
 static void i915_driver_cleanup_hw(struct drm_i915_private *dev_priv)
 {
-#ifdef __linux__
+#if defined(__linux__) || defined(pci_disable_msi)
 	struct pci_dev *pdev = dev_priv->drm.pdev;
+#endif
 
+#ifdef CONFIG_I915_PERF
+	i915_perf_fini(dev_priv);
+#endif
+
+#if defined(__linux__) || defined(pci_disable_msi)
 	if (pdev->msi_enabled)
 		pci_disable_msi(pdev);
 #endif

--- a/linuxkpi/gplv2/src/linux_compat.c
+++ b/linuxkpi/gplv2/src/linux_compat.c
@@ -2,6 +2,7 @@
 #include <sys/kernel.h>
 
 #include <machine/specialreg.h>
+#include <sys/pcpu.h>
 #include <machine/md_var.h>
 
 #include <linux/bitops.h>

--- a/radeon/radeon_irq_kms.c
+++ b/radeon/radeon_irq_kms.c
@@ -294,7 +294,7 @@ int radeon_irq_kms_init(struct radeon_device *rdev)
 	rdev->msi_enabled = 0;
 
 	if (radeon_msi_ok(rdev)) {
-#ifdef __linux__
+#if defined(__linux__) || defined(pci_enable_msi)
 		int ret = pci_enable_msi(rdev->pdev);
 		if (!ret) {
 			rdev->msi_enabled = 1;
@@ -332,7 +332,7 @@ void radeon_irq_kms_fini(struct radeon_device *rdev)
 	if (rdev->irq.installed) {
 		drm_irq_uninstall(rdev->ddev);
 		rdev->irq.installed = false;
-#ifdef __linux__
+#if defined(__linux__) || defined(pci_disable_msi)
 		if (rdev->msi_enabled)
 			pci_disable_msi(rdev->pdev);
 #endif


### PR DESCRIPTION
These changes allow running the 4.11 kmod on recentish stable/12, by cherrypicking back several recent changes from the 4.16 branch.  I've now had several weeks on a radeonkms and an amdgpu system, without obvious incident.

This _compiles_ against a stable/11 sys/ tree, but I don't have any 11.2 systems around to try running it on.  I wouldn't naively expect issues from the sort of changes involved; if there were, I'd expect the MSI changes would be the likely cause.

In a minimalistic mold, the header added in linuxkpi/gplv2/src/linux_compat.c _may_ be the only bit strictly necessary to get it to build and run on 12.