### PR TITLE
drm/i915/gen9: PSIRT-TA-201910-001 [drm-v5.0]

### DIFF
--- a/drivers/gpu/drm/i915/intel_lrc.c
+++ b/drivers/gpu/drm/i915/intel_lrc.c
@@ -1416,6 +1416,15 @@ static u32 *gen9_init_indirectctx_bb(struct intel_engine_cs *engine, u32 *batch)
 	/* WaFlushCoherentL3CacheLinesAtContextSwitch:skl,bxt,glk */
 	batch = gen8_emit_flush_coherentl3_wa(engine, batch);
 
+	/* WaClearSlmSpaceAtContextSwitch:skl,bxt,kbl,glk,cfl */
+	batch = gen8_emit_pipe_control(batch,
+				       PIPE_CONTROL_FLUSH_L3 |
+				       PIPE_CONTROL_STORE_DATA_INDEX |
+				       PIPE_CONTROL_CS_STALL |
+				       PIPE_CONTROL_QW_WRITE,
+				       i915_scratch_offset(engine->i915) +
+				       2 * CACHELINE_BYTES);
+
 	batch = emit_lri(batch, lri, ARRAY_SIZE(lri));
 
 	/* WaMediaPoolStateCmdInWABB:bxt,glk */


### PR DESCRIPTION
Intel ID: PSIRT-TA-201910-001 
CVEID: CVE-2019-14615

Summary of Vulnerability
------------------------
Insufficient control flow in certain data structures for
some Intel(R) Processors with Intel Processor Graphics 
may allow an unauthenticated user to potentially enable
information disclosure via local access

Products affected:
------------------
Intel CPU’s with Gen7, Gen7.5 and Gen9 Graphics.

Mitigation Summary
------------------
This patch provides mitigation for Gen9 hardware only.
Patches for Gen7 and Gen7.5 will be provided later.
Note that Gen8 is not impacted due to a previously
implemented workaround.

The mitigation involves using an existing hardware
feature to forcibly clear down all EU state at each
context switch.
