### PR TITLE
 drm/i915/gen9: PSIRT-TA-201910-001 [drm-v4.16-fbsd12.0]

### DIFF
--- a/drivers/gpu/drm/i915/intel_lrc.c
+++ b/drivers/gpu/drm/i915/intel_lrc.c
@@ -1318,6 +1318,15 @@ static u32 *gen9_init_indirectctx_bb(struct intel_engine_cs *engine, u32 *batch)
 	/* WaFlushCoherentL3CacheLinesAtContextSwitch:skl,bxt,glk */
 	batch = gen8_emit_flush_coherentl3_wa(engine, batch);
 
+	/* WaClearSlmSpaceAtContextSwitch:skl,bxt,kbl,glk */
+	batch = gen8_emit_pipe_control(batch,
+				       PIPE_CONTROL_FLUSH_L3 |
+				       PIPE_CONTROL_GLOBAL_GTT_IVB |
+				       PIPE_CONTROL_CS_STALL |
+				       PIPE_CONTROL_QW_WRITE,
+				       i915_ggtt_offset(engine->scratch) +
+				       2 * CACHELINE_BYTES);
+
 	/* WaDisableGatherAtSetShaderCommonSlice:skl,bxt,kbl,glk */
 	*batch++ = MI_LOAD_REGISTER_IMM(1);
 	*batch++ = i915_mmio_reg_offset(COMMON_SLICE_CHICKEN2);


### PR DESCRIPTION
Intel ID: PSIRT-TA-201910-001 
CVEID: CVE-2019-14615

Summary of Vulnerability
------------------------
Insufficient control flow in certain data structures for
some Intel(R) Processors with Intel Processor Graphics 
may allow an unauthenticated user to potentially enable
information disclosure via local access

Products affected:
------------------
Intel CPU’s with Gen7, Gen7.5 and Gen9 Graphics.

Mitigation Summary
------------------
This patch provides mitigation for Gen9 hardware only.
Patches for Gen7 and Gen7.5 will be provided later.
Note that Gen8 is not impacted due to a previously
implemented workaround.

The mitigation involves using an existing hardware
feature to forcibly clear down all EU state at each
context switch.
