### PR TITLE
Fix I915_USERPTR_UNSYNCHRONIZED for Vulkan on old Haswell cards

### DIFF
--- a/drivers/gpu/drm/i915/i915_gem_userptr.c
+++ b/drivers/gpu/drm/i915/i915_gem_userptr.c
@@ -495,14 +495,6 @@ __i915_gem_userptr_set_active(struct drm_i915_gem_object *obj,
 	return ret;
 }
 
-/* originally from linux's mm.h */
-static inline bool
-mmget_not_zero(struct mm_struct *mm)
-{
-        /* mm_users is the number of things using this real address space */
-        return atomic_inc_not_zero(&mm->mm_users);
-}
-
 static void
 __i915_gem_userptr_get_pages_worker(struct work_struct *_work)
 {

--- a/drivers/gpu/drm/i915/i915_gem_userptr.c
+++ b/drivers/gpu/drm/i915/i915_gem_userptr.c
@@ -495,6 +495,14 @@ __i915_gem_userptr_set_active(struct drm_i915_gem_object *obj,
 	return ret;
 }
 
+/* originally from linux's mm.h */
+static inline bool
+mmget_not_zero(struct mm_struct *mm)
+{
+        /* mm_users is the number of things using this real address space */
+        return atomic_inc_not_zero(&mm->mm_users);
+}
+
 static void
 __i915_gem_userptr_get_pages_worker(struct work_struct *_work)
 {
@@ -509,7 +517,6 @@ __i915_gem_userptr_get_pages_worker(struct work_struct *_work)
 
 	pvec = kvmalloc_array(npages, sizeof(struct page *), GFP_KERNEL);
 	if (pvec != NULL) {
-#ifdef __linux__
 		struct mm_struct *mm = obj->userptr.mm->mm;
 		unsigned int flags = 0;
 
@@ -525,7 +532,11 @@ __i915_gem_userptr_get_pages_worker(struct work_struct *_work)
 					 obj->userptr.ptr + pinned * PAGE_SIZE,
 					 npages - pinned,
 					 flags,
+#ifdef __linux__
 					 pvec + pinned, NULL, NULL);
+#else
+					 pvec + pinned, NULL);
+#endif
 				if (ret < 0)
 					break;
 
@@ -534,10 +545,6 @@ __i915_gem_userptr_get_pages_worker(struct work_struct *_work)
 			up_read(&mm->mmap_sem);
 			mmput(mm);
 		}
-#else
-		/* XXXmarkj this code is non-functional anyway. */
-		ret = -EFAULT;
-#endif
 	}
 
 	mutex_lock(&obj->mm.lock);


### PR DESCRIPTION
This lets the unsynchronized `DRM_IOCTL_I915_GEM_USERPTR` hack work in mesa on 7th generation Haswell graphics. This was needed to get Vulkan working on the Toshiba Satellite L55t-A5232 with current.

The userptr ioctl isn't needed anymore thanks to the softpin feature in mesa 19.0 and later. The issue is that softpin requires hardware of the 8th generation or later, along with support for 48-bit addresses. The old and terrible Toshiba laptop I am testing on does not have either of these things, so this patch was required.

Please let me know what you all think about this, and if it needs improvement. I'm happy to provide any details or testing.

`i915_gem_userptr_get_pages` will allocate and pin the number of pages requested. If this does not immediately pin all of the pages it will defer to `__i915_gem_userptr_get_pages_worker` to complete the request. A section of `__i915_gem_userptr_get_pages_worker` was halfway ifdef-ed out, but almost all of the linuxkpi functions were implemented. That section is in charge of pinning the remaining pages and without it the ioctl fails.

## Questions
The only linuxkpi function not implemented was `mmget_not_zero`, which is supposed to be in linux's mm.h. I added it above `__i915_gem_userptr_get_pages_worker`, as that is the only function that uses it. Maybe it would be better included in the main linuxkpi? Please let me know where it best belongs. If it needs to be committed to current I have a tiny patch to do so laying around.

`get_user_pages_remote` seemed to have an inconsistent number of arguments. The drm code has the number used by current versions of Linux, but the linuxkpi doesn't expect the last argument. Maybe this needs to be updated in the linuxkpi? I'm happy to do so if required.