### PR TITLE
Update version check to work on CURRENT

### DIFF
--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_amdkfd.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_amdkfd.c
@@ -281,14 +281,10 @@ void get_local_mem_info(struct kgd_dev *kgd,
 			struct kfd_local_mem_info *mem_info)
 {
 	struct amdgpu_device *adev = (struct amdgpu_device *)kgd;
-#if __FreeBSD_version < 1300021
-	uint64_t address_mask = adev->dev->dma_mask ? ~*adev->dev->dma_mask :
-#else
         /* BSDFIXME: Change required by D19845. Sketchy conversion depends
          * on dma_mask being the first member of dma_priv 
 	 */
 	uint64_t address_mask = adev->dev->dma_priv ? ~*((uint64_t*)adev->dev->dma_priv) :
-#endif
 					     ~((1ULL << 32) - 1);
 	resource_size_t aper_limit = adev->mc.aper_base + adev->mc.aper_size;
 

--- a/drivers/gpu/drm/ttm/ttm_page_alloc.c
+++ b/drivers/gpu/drm/ttm/ttm_page_alloc.c
@@ -315,13 +315,6 @@ static void ttm_pages_put(struct page *pages[], unsigned npages,
 			if (set_pages_wb(pages[i], pages_nr))
 				pr_err("Failed to set %d pages to wb!\n", pages_nr);
 		}
-#ifndef __linux__
-#if __FreeBSD_version < 1300031
-		vm_page_lock(pages[i]);
-		vm_page_unwire(pages[i], PQ_NONE);
-		vm_page_unlock(pages[i]);
-#endif
-#endif
 		__free_pages(pages[i], order);
 	}
 }
@@ -563,11 +556,6 @@ static void ttm_handle_caching_state_failure(struct pglist *pages,
 		list_del(&failed_pages[i]->lru);
 #else
 		TAILQ_REMOVE(pages, failed_pages[i], plinks.q);
-#if __FreeBSD_version < 1300031
-		vm_page_lock(failed_pages[i]);
-		vm_page_unwire(failed_pages[i], PQ_NONE);
-		vm_page_unlock(failed_pages[i]);
-#endif
 #endif
 		__free_page(failed_pages[i]);
 	}
@@ -625,11 +613,6 @@ static int ttm_alloc_new_pages(struct pglist *pages, gfp_t gfp_flags,
 #ifdef __linux__
 		list_add(&p->lru, pages);
 #else
-#if __FreeBSD_version < 1300031
-		vm_page_lock(p);
-		vm_page_wire(p);
-		vm_page_unlock(p);
-#endif
 		TAILQ_INSERT_HEAD(pages, p, plinks.q);
 #endif
 
@@ -892,13 +875,6 @@ static void ttm_put_pages(struct page **pages, unsigned npages, int flags,
 
 			if (page_count(pages[i]) != 1)
 				pr_err("Erroneous page count. Leaking pages.\n");
-#ifndef __linux__
-#if __FreeBSD_version < 1300031
-			vm_page_lock(pages[i]);
-			vm_page_unwire(pages[i], PQ_NONE);
-			vm_page_unlock(pages[i]);
-#endif
-#endif
 			__free_pages(pages[i], order);
 
 			j = 1 << order;
@@ -1046,13 +1022,6 @@ static int ttm_get_pages(struct page **pages, unsigned npages, int flags,
 				return -ENOMEM;
 			}
 
-#ifndef __linux__
-#if __FreeBSD_version < 1300031
-			vm_page_lock(p);
-			vm_page_wire(p);
-			vm_page_unlock(p);
-#endif
-#endif
 			/* Swap the pages if we detect consecutive order */
 			if (i > first && pages[i - 1] == p - 1)
 				swap(p, pages[i - 1]);

--- a/linuxkpi/gplv2/include/linux/mm_types.h
+++ b/linuxkpi/gplv2/include/linux/mm_types.h
@@ -3,8 +3,7 @@
 
 #include_next <linux/mm_types.h>
 
-#if (__FreeBSD_version >= 1100000 && __FreeBSD_version < 1103508) || \
-    (__FreeBSD_version >= 1200000 && __FreeBSD_version < 1201512)
+#if __FreeBSD_version < 1300077
 static inline bool
 mmget_not_zero(struct mm_struct *mm)
 {

--- a/linuxkpi/gplv2/include/linux/pagevec.h
+++ b/linuxkpi/gplv2/include/linux/pagevec.h
@@ -46,9 +46,6 @@ static inline unsigned pagevec_space(struct pagevec *pvec)
  */
 static inline unsigned pagevec_add(struct pagevec *pvec, struct page *page)
 {
-#if __FreeBSD_version < 1300031
-	get_page(page); // fix to wire_count = 0 panic at release
-#endif
 	pvec->pages[pvec->nr++] = page;
 	return pagevec_space(pvec);
 }

--- a/linuxkpi/gplv2/src/linux_page.c
+++ b/linuxkpi/gplv2/src/linux_page.c
@@ -239,13 +239,8 @@ retry:
 			page = vm_page_lookup(devobj, i);
 			if (page == NULL)
 				continue;
-#if __FreeBSD_version >= 1300052
 			if (!vm_page_busy_acquire(page, VM_ALLOC_WAITFAIL))
 				goto retry;
-#else
-			if (vm_page_sleep_if_busy(page, "linuxkpi"))
-				goto retry;
-#endif
 			cdev_pager_free_page(devobj, page);
 		}
 		VM_OBJECT_WUNLOCK(devobj);


### PR DESCRIPTION
Update the version check to work on FreeBSD current instead of 11 and
12.
There is no need to take FreeBSD 11 and 12 into account here, since this
branch is for 13 and later only.