### PR TITLE
Backport HOTPLUG support to 4.11 for FreeBSD 11.*

### DIFF
--- a/drm/drm_sysfs.c
+++ b/drm/drm_sysfs.c
@@ -340,6 +340,15 @@ void drm_sysfs_hotplug_event(struct drm_device *dev)
 	DRM_DEBUG("generating hotplug event\n");
 
 	kobject_uevent_env(&dev->primary->kdev->kobj, KOBJ_CHANGE, envp);
+#else
+	struct sbuf *sb = sbuf_new_auto();
+
+	DRM_DEBUG("generating hotplug event\n");
+
+	sbuf_printf(sb, "cdev=dri/%s", dev_name(dev->primary->kdev));
+	sbuf_finish(sb);
+	devctl_notify("DRM", "CONNECTOR", "HOTPLUG", sbuf_data(sb));
+	sbuf_delete(sb);
 #endif
 }
 EXPORT_SYMBOL(drm_sysfs_hotplug_event);


### PR DESCRIPTION
Required by https://github.com/swaywm/wlroots/pull/2027. Tested on -CURRENT (with drm-v4.16 build fixes) and Sway 1.2 (ports r510011).