### PR TITLE
Backport DRM_CRTC_IN_VBLANK for wlroots >= 0.7 on FreeBSD 11.*

### DIFF
--- a/drm/drm_ioctl.c
+++ b/drm/drm_ioctl.c
@@ -290,6 +290,9 @@ static int drm_getcap(struct drm_device *dev, void *data, struct drm_file *file_
 	case DRM_CAP_ADDFB2_MODIFIERS:
 		req->value = dev->mode_config.allow_fb_modifiers;
 		break;
+	case DRM_CAP_CRTC_IN_VBLANK_EVENT:
+		req->value = 1;
+		break;
 	default:
 		return -EINVAL;
 	}

--- a/drm/drm_irq.c
+++ b/drm/drm_irq.c
@@ -1001,6 +1001,7 @@ void drm_crtc_arm_vblank_event(struct drm_crtc *crtc,
 
 	e->pipe = pipe;
 	e->event.sequence = drm_vblank_count(dev, pipe);
+	e->event.crtc_id = crtc->base.id;
 	list_add_tail(&e->base.link, &dev->vblank_event_list);
 }
 EXPORT_SYMBOL(drm_crtc_arm_vblank_event);
@@ -1031,6 +1032,7 @@ void drm_crtc_send_vblank_event(struct drm_crtc *crtc,
 		now = get_drm_timestamp();
 	}
 	e->pipe = pipe;
+	e->event.crtc_id = crtc->base.id;
 	send_vblank_event(dev, e, seq, &now);
 }
 EXPORT_SYMBOL(drm_crtc_send_vblank_event);

--- a/include/uapi/drm/drm.h
+++ b/include/uapi/drm/drm.h
@@ -651,6 +651,7 @@ struct drm_gem_open {
 #define DRM_CAP_CURSOR_HEIGHT		0x9
 #define DRM_CAP_ADDFB2_MODIFIERS	0x10
 #define DRM_CAP_PAGE_FLIP_TARGET	0x11
+#define DRM_CAP_CRTC_IN_VBLANK_EVENT	0x12
 
 /** DRM_IOCTL_GET_CAP ioctl argument type */
 struct drm_get_cap {
@@ -855,7 +856,7 @@ struct drm_event_vblank {
 	__u32 tv_sec;
 	__u32 tv_usec;
 	__u32 sequence;
-	__u32 reserved;
+	__u32 crtc_id; /* 0 on older kernels that do not support this */
 };
 
 /* typedef area */


### PR DESCRIPTION
Required by https://github.com/swaywm/wlroots/pull/1738 (or https://github.com/freebsd/freebsd-ports/commit/ab8a57f405f4) to fix the following error. Tested on -CURRENT (with drm-v4.16 build fixes) and Sway 1.4.
```
$ sway -dc /dev/null
[...]
[sway/server.c:40] Preparing Wayland server initialization
[backend/session/direct-freebsd.c:207] Using tty /dev/ttyv3
[backend/session/direct-freebsd.c:296] Successfully loaded direct session
[backend/backend.c:157] Found 1 GPUs
[backend/drm/backend.c:159] Initializing DRM backend for /dev/dri/card0 (i915)
[backend/drm/drm.c:56] DRM_CRTC_IN_VBLANK_EVENT unsupported
[backend/backend.c:163] Failed to open DRM device 12
[backend/backend.c:304] Failed to open any DRM device
[backend/noop/backend.c:51] Creating noop backend
[sway/server.c:47] Unable to create backend
```
