### PR TITLE
Backport to 4.9 enough to make wlroots >= 0.7 work on -CURRENT

### DIFF
--- a/amd/amdgpu/amdgpu_irq.c
+++ b/amd/amdgpu/amdgpu_irq.c
@@ -37,8 +37,6 @@
 #include <linux/pm_runtime.h>
 
 #define AMDGPU_WAIT_IDLE_TIMEOUT 200
-#define pci_enable_msi linux_pci_enable_msi
-#define pci_disable_msi linux_pci_disable_msi
 
 /*
  * Handle hotplug events outside the interrupt handler proper.
@@ -226,7 +224,7 @@ int amdgpu_irq_init(struct amdgpu_device *adev)
 	adev->irq.msi_enabled = false;
 
 	if (amdgpu_msi_ok(adev)) {
-#ifndef __FreeBSD__
+#if defined(__linux__) || defined(pci_enable_msi)
 		int ret = pci_enable_msi(adev->pdev);
 		if (!ret) {
 			adev->irq.msi_enabled = true;
@@ -266,7 +264,7 @@ void amdgpu_irq_fini(struct amdgpu_device *adev)
 	if (adev->irq.installed) {
 		drm_irq_uninstall(adev->ddev);
 		adev->irq.installed = false;
-#ifndef __FreeBSD__
+#if defined(__linux__) || defined(pci_disable_msi)
 		if (adev->irq.msi_enabled)
 			pci_disable_msi(adev->pdev);
 #endif

--- a/drm/drm_atomic.c
+++ b/drm/drm_atomic.c
@@ -819,10 +819,10 @@ static int drm_atomic_plane_check(struct drm_plane *plane,
 	int ret;
 
 	/* either *both* CRTC and FB must be set, or neither */
-	if (WARN_ON(state->crtc && !state->fb)) {
+	if (state->crtc && !state->fb) {
 		DRM_DEBUG_ATOMIC("CRTC set but no FB\n");
 		return -EINVAL;
-	} else if (WARN_ON(state->fb && !state->crtc)) {
+	} else if (state->fb && !state->crtc) {
 		DRM_DEBUG_ATOMIC("FB set but no CRTC\n");
 		return -EINVAL;
 	}

--- a/drm/drm_ioctl.c
+++ b/drm/drm_ioctl.c
@@ -277,6 +277,9 @@ static int drm_getcap(struct drm_device *dev, void *data, struct drm_file *file_
 	case DRM_CAP_ADDFB2_MODIFIERS:
 		req->value = dev->mode_config.allow_fb_modifiers;
 		break;
+	case DRM_CAP_CRTC_IN_VBLANK_EVENT:
+		req->value = 1;
+		break;
 	default:
 		return -EINVAL;
 	}

--- a/drm/drm_irq.c
+++ b/drm/drm_irq.c
@@ -1052,6 +1052,7 @@ void drm_crtc_arm_vblank_event(struct drm_crtc *crtc,
 
 	e->pipe = pipe;
 	e->event.sequence = drm_vblank_count(dev, pipe);
+	e->event.crtc_id = crtc->base.id;
 	list_add_tail(&e->base.link, &dev->vblank_event_list);
 }
 EXPORT_SYMBOL(drm_crtc_arm_vblank_event);
@@ -1082,6 +1083,7 @@ void drm_crtc_send_vblank_event(struct drm_crtc *crtc,
 		now = get_drm_timestamp();
 	}
 	e->pipe = pipe;
+	e->event.crtc_id = crtc->base.id;
 	send_vblank_event(dev, e, seq, &now);
 }
 EXPORT_SYMBOL(drm_crtc_send_vblank_event);

--- a/drm/drm_os_freebsd.c
+++ b/drm/drm_os_freebsd.c
@@ -31,7 +31,6 @@ SYSCTL_INT(_dev_drm, OID_AUTO, error_panic, CTLFLAG_RWTUN, &drm_panic_on_error, 
 int drm_always_interruptible;
 SYSCTL_INT(_dev_drm, OID_AUTO, always_interruptible, CTLFLAG_RWTUN, &drm_always_interruptible, 0, "always allow a thread to be interrupted in driver wait");
 
-static atomic_t reset_debug_log_armed = ATOMIC_INIT(0);
 static struct callout reset_debug_log_handle;
 
 static void
@@ -43,8 +42,7 @@ clear_debug_func(void *arg __unused)
 void
 cancel_reset_debug_log(void)
 {
-	if (atomic_read(&reset_debug_log_armed))
-		callout_stop(&reset_debug_log_handle);
+	callout_stop(&reset_debug_log_handle);
 }
 
 static void
@@ -53,9 +51,8 @@ reset_debug_log(void)
 	if (drm_debug_persist)
 		return;
 
-	if (atomic_add_unless(&reset_debug_log_armed, 1, 1)) {
+	if (!callout_pending(&reset_debug_log_handle))
 		callout_reset(&reset_debug_log_handle, 10*hz, clear_debug_func, NULL);
-	}
 }
 
 int
@@ -312,6 +309,9 @@ drm_modevent(module_t mod, int type, void *data)
 	case MOD_LOAD:
 		TUNABLE_INT_FETCH("drm.debug", &drm_debug);
 		callout_init(&reset_debug_log_handle, 1);
+		break;
+	case MOD_UNLOAD:
+		callout_drain(&reset_debug_log_handle);
 		break;
 	}
 	return (0);

--- a/drm/drm_os_freebsd.c
+++ b/drm/drm_os_freebsd.c
@@ -32,7 +32,7 @@ int drm_always_interruptible;
 SYSCTL_INT(_dev_drm, OID_AUTO, always_interruptible, CTLFLAG_RWTUN, &drm_always_interruptible, 0, "always allow a thread to be interrupted in driver wait");
 
 static atomic_t reset_debug_log_armed = ATOMIC_INIT(0);
-static struct callout_handle reset_debug_log_handle;
+static struct callout reset_debug_log_handle;
 
 static void
 clear_debug_func(void *arg __unused)
@@ -44,7 +44,7 @@ void
 cancel_reset_debug_log(void)
 {
 	if (atomic_read(&reset_debug_log_armed))
-		untimeout(clear_debug_func, NULL, reset_debug_log_handle);
+		callout_stop(&reset_debug_log_handle);
 }
 
 static void
@@ -54,8 +54,7 @@ reset_debug_log(void)
 		return;
 
 	if (atomic_add_unless(&reset_debug_log_armed, 1, 1)) {
-		reset_debug_log_handle = timeout(clear_debug_func, NULL,
-		    10*hz);
+		callout_reset(&reset_debug_log_handle, 10*hz, clear_debug_func, NULL);
 	}
 }
 
@@ -312,6 +311,7 @@ drm_modevent(module_t mod, int type, void *data)
 	switch (type) {
 	case MOD_LOAD:
 		TUNABLE_INT_FETCH("drm.debug", &drm_debug);
+		callout_init(&reset_debug_log_handle, 1);
 		break;
 	}
 	return (0);

--- a/drm/drm_sysctl.c
+++ b/drm/drm_sysctl.c
@@ -419,8 +419,8 @@ static int drm_vblank_info DRM_SYSCTL_HANDLER_ARGS
 	int retcode;
 	int i;
 
-	DRM_SYSCTL_PRINT("\ncrtc ref count    last     enabled inmodeset\n");
 	mutex_lock(&dev->struct_mutex);
+	DRM_SYSCTL_PRINT("\ncrtc ref count    last     enabled inmodeset\n");
 	if (dev->vblank == NULL)
 		goto done;
 	for (i = 0 ; i < dev->num_crtcs ; i++) {

--- a/drm/drm_sysfs.c
+++ b/drm/drm_sysfs.c
@@ -338,6 +338,15 @@ void drm_sysfs_hotplug_event(struct drm_device *dev)
 	DRM_DEBUG("generating hotplug event\n");
 
 	kobject_uevent_env(&dev->primary->kdev->kobj, KOBJ_CHANGE, envp);
+#else
+	struct sbuf *sb = sbuf_new_auto();
+
+	DRM_DEBUG("generating hotplug event\n");
+
+	sbuf_printf(sb, "cdev=dri/%s", dev_name(dev->primary->kdev));
+	sbuf_finish(sb);
+	devctl_notify("DRM", "CONNECTOR", "HOTPLUG", sbuf_data(sb));
+	sbuf_delete(sb);
 #endif
 }
 EXPORT_SYMBOL(drm_sysfs_hotplug_event);

--- a/i915/i915_drv.c
+++ b/i915/i915_drv.c
@@ -1128,7 +1128,7 @@ static int i915_driver_init_hw(struct drm_i915_private *dev_priv)
 
 	i915_gem_load_init_fences(dev_priv);
 
-#ifndef __FreeBSD__
+#if defined(__linux__) || defined(pci_enable_msi)
 	/* On the 945G/GM, the chipset reports the MSI capability on the
 	 * integrated graphics even though the support isn't actually there
 	 * according to the published specs.  It doesn't appear to function
@@ -1160,9 +1160,11 @@ out_ggtt:
  */
 static void i915_driver_cleanup_hw(struct drm_i915_private *dev_priv)
 {
-#ifndef __FreeBSD__
+#if defined(__linux__) || defined(pci_disable_msi)
 	struct pci_dev *pdev = dev_priv->drm.pdev;
+#endif
 
+#if defined(__linux__) || defined(pci_disable_msi)
 	if (pdev->msi_enabled)
 		pci_disable_msi(pdev);
 #endif

--- a/include/uapi/drm/drm.h
+++ b/include/uapi/drm/drm.h
@@ -655,6 +655,7 @@ struct drm_gem_open {
 #define DRM_CAP_CURSOR_HEIGHT		0x9
 #define DRM_CAP_ADDFB2_MODIFIERS	0x10
 #define DRM_CAP_PAGE_FLIP_TARGET	0x11
+#define DRM_CAP_CRTC_IN_VBLANK_EVENT	0x12
 
 /** DRM_IOCTL_GET_CAP ioctl argument type */
 struct drm_get_cap {
@@ -859,7 +860,7 @@ struct drm_event_vblank {
 	__u32 tv_sec;
 	__u32 tv_usec;
 	__u32 sequence;
-	__u32 reserved;
+	__u32 crtc_id; /* 0 on older kernels that do not support this */
 };
 
 /* typedef area */

--- a/linuxkpi/gplv2/include/linux/dma-buf.h
+++ b/linuxkpi/gplv2/include/linux/dma-buf.h
@@ -132,9 +132,17 @@ struct dma_buf_attachment {
 static inline void
 get_dma_buf(struct dma_buf *dmabuf)
 {
+	/*
+	 * As of r350199 fhold changed from macro to a function returning
+	 * true/false at success/failure to avoid overflow.
+	 */
+#ifdef fhold
+	fhold(dmabuf->file);
+#else
 	while(!fhold(dmabuf->file)) {
 		pause("fhold", hz);
 	}
+#endif
 }
 
 

--- a/linuxkpi/gplv2/include/linux/dma-buf.h
+++ b/linuxkpi/gplv2/include/linux/dma-buf.h
@@ -132,7 +132,9 @@ struct dma_buf_attachment {
 static inline void
 get_dma_buf(struct dma_buf *dmabuf)
 {
-	fhold(dmabuf->file);
+	while(!fhold(dmabuf->file)) {
+		pause("fhold", hz);
+	}
 }
 
 

--- a/linuxkpi/gplv2/include/linux/shmem_fs.h
+++ b/linuxkpi/gplv2/include/linux/shmem_fs.h
@@ -1,0 +1,3 @@
+#if __FreeBSD_version >= 1300081
+#include_next <linux/shmem_fs.h>
+#endif

--- a/linuxkpi/gplv2/src/linux_compat.c
+++ b/linuxkpi/gplv2/src/linux_compat.c
@@ -1,6 +1,7 @@
 #include <sys/param.h>
 #include <sys/kernel.h>
 
+#include <sys/pcpu.h>
 #include <machine/specialreg.h>
 #include <machine/md_var.h>
 

--- a/linuxkpi/gplv2/src/linux_i2c.c
+++ b/linuxkpi/gplv2/src/linux_i2c.c
@@ -302,6 +302,9 @@ i2c_sendbyte(struct i2c_algo_bit_data *adap, unsigned char data)
 		}
 	}
 
+	sdahi(adap);
+	if (sclhi(adap) < 0)
+		return (-ETIMEDOUT);
 	ack = (getsda(adap) == 0);
 	scllo(adap);
 	return ack;

--- a/linuxkpi/gplv2/src/linux_page.c
+++ b/linuxkpi/gplv2/src/linux_page.c
@@ -249,8 +249,13 @@ retry:
 			page = vm_page_lookup(devobj, i);
 			if (page == NULL)
 				continue;
+#if __FreeBSD_version >= 1300052
+			if (!vm_page_busy_acquire(page, VM_ALLOC_WAITFAIL))
+				goto retry;
+#else
 			if (vm_page_sleep_if_busy(page, "linuxkpi"))
 				goto retry;
+#endif
 			cdev_pager_free_page(devobj, page);
 		}
 		VM_OBJECT_WUNLOCK(devobj);

--- a/radeon/radeon_irq_kms.c
+++ b/radeon/radeon_irq_kms.c
@@ -298,7 +298,7 @@ int radeon_irq_kms_init(struct radeon_device *rdev)
 	rdev->msi_enabled = 0;
 
 	if (radeon_msi_ok(rdev)) {
-#ifndef __FreeBSD__
+#if defined(__linux__) || defined(pci_enable_msi)
 		int ret = pci_enable_msi(rdev->pdev);
 		if (!ret) {
 			rdev->msi_enabled = 1;
@@ -336,7 +336,7 @@ void radeon_irq_kms_fini(struct radeon_device *rdev)
 	if (rdev->irq.installed) {
 		drm_irq_uninstall(rdev->ddev);
 		rdev->irq.installed = false;
-#ifndef __FreeBSD__
+#if defined(__linux__) || defined(pci_disable_msi)
 		if (rdev->msi_enabled)
 			pci_disable_msi(rdev->pdev);
 #endif


### PR DESCRIPTION
`drm-v4.9` was a long-lived branch, being very stable near EOL. Make it usable again e.g., for debugging issues on newer branches or as a last resort by users.

I'm not really expecting this to be merged but it builds fine on FreeBSD 11.3 as well.
