### PR TITLE
enable CONFIG_DRM_AMD_DC_DCN1_01 on amd64

### DIFF
--- a/drivers/gpu/drm/drm_os_config.h
+++ b/drivers/gpu/drm/drm_os_config.h
@@ -134,6 +134,7 @@
 #define	CONFIG_DRM_AMD_DC 1
 #ifdef __amd64__
 #define	CONFIG_DRM_AMD_DC_DCN1_0 1
+#define	CONFIG_DRM_AMD_DC_DCN1_01 1
 #endif
 
 // Frame buffer compression on AMD DC


### PR DESCRIPTION
This allows amdgpu to work with my Vega 3 (Raven 2) graphics integrated into  Ryzen 3 3200U.
Without CONFIG_DRM_AMD_DC_DCN1_01 there is not signal on the screen despite the driver successfully attaching. I see that driver incorrectly detects the number of pipes and timing generators (4 instead of 3). And probably there are other problems with talking to the hardware.