### PR TITLE
drm/amdgpu/psp: ignore psp response status

### DIFF
--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_psp.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_psp.c
@@ -142,14 +142,19 @@ psp_cmd_submit_buf(struct psp_context *psp,
 	while (*((unsigned int *)psp->fence_buf) != index)
 		msleep(1);
 
-	/* the status field must be 0 after psp command completion */
+	/* In some cases, psp response status is not 0 even there is no
+	 * problem while the command is submitted. Some version of PSP FW
+	 * doesn't write 0 to that field.
+	 * So here we would like to only print a warning instead of an error
+	 * during psp initialization to avoid breaking hw_init and it doesn't
+	 * return -EINVAL.
+	 */
 	if (psp->cmd_buf_mem->resp.status) {
 		if (ucode)
-			DRM_ERROR("failed to load ucode id (%d) ",
+			DRM_WARN("failed to load ucode id (%d) ",
 				  ucode->ucode_id);
-		DRM_ERROR("psp command failed and response status is (%d)\n",
+		DRM_WARN("psp command failed and response status is (%d)\n",
 			  psp->cmd_buf_mem->resp.status);
-		return -EINVAL;
 	}
 
 	if (ucode) {

--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_psp.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_psp.c
@@ -142,10 +142,13 @@ psp_cmd_submit_buf(struct psp_context *psp,
 	while (*((unsigned int *)psp->fence_buf) != index)
 		msleep(1);
 
-	/* the status field must be 0 after FW is loaded */
-	if (ucode && psp->cmd_buf_mem->resp.status) {
-		DRM_ERROR("failed loading with status (%d) and ucode id (%d)\n",
-			  psp->cmd_buf_mem->resp.status, ucode->ucode_id);
+	/* the status field must be 0 after psp command completion */
+	if (psp->cmd_buf_mem->resp.status) {
+		if (ucode)
+			DRM_ERROR("failed to load ucode id (%d) ",
+				  ucode->ucode_id);
+		DRM_ERROR("psp command failed and response status is (%d)\n",
+			  psp->cmd_buf_mem->resp.status);
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
This PR picks up two upstream commits.
On my hardware both Linux (5.3.x) and FreeBSD amdgpu drivers report similar errors:
```
[    6.603437] [drm] failed to load ucode id (12) 
[    6.603440] [drm] psp command failed and response status is (-53233)
[    6.619445] [drm] failed to load ucode id (13) 
[    6.619446] [drm] psp command failed and response status is (-65521)
[    6.631459] [drm] failed to load ucode id (14) 
[    6.631462] [drm] psp command failed and response status is (-65521)
```
```
[drm ERROR :psp_cmd_submit_buf] failed loading with status (-53233) and ucode id (10)
[drm ERROR :psp_hw_init] PSP firmware loading failed
[drm ERROR :amdgpu_device_fw_loading] hw_init of IP block <psp> failed -22
drmn0: amdgpu_device_ip_init failed
drmn0: Fatal error during GPU init
```
The obvious difference is that on Linux the error is not fatal while on FreeBSD it was.
After the change, FreeBSD amdgpu is able to attach successfully:
```
[drm] failed to load ucode id (10) <4>[drm] psp command failed and response status is (-53233)
[drm] failed to load ucode id (11) <4>[drm] psp command failed and response status is (-65521)
[drm] failed to load ucode id (12) <4>[drm] psp command failed and response status is (-65521)
```