### PR TITLE
linuxkpi: remove pci_iomap/pci_iounmap

### DIFF
--- a/linuxkpi/gplv2/include/linux/pci.h
+++ b/linuxkpi/gplv2/include/linux/pci.h
@@ -172,17 +172,4 @@ pcie_get_readrq(struct pci_dev *dev)
 	return 128 << ((ctl & PCI_EXP_DEVCTL_READRQ) >> 12);
 }
 
-static inline void *
-pci_iomap(struct pci_dev *dev, int bar, unsigned long maxlen)
-{
-
-	panic("pci_iomap is not supported");
-}
-
-static inline void
-pci_iounmap(struct pci_dev *dev, void *addr)
-{
-	/* NOP */
-}
-
 #endif /* _LINUX_GPLV2_PCI_H_ */


### PR DESCRIPTION
Those will be added in base linuxkpi.

Signed-off-by: Emmanuel Vadot <manu@FreeBSD.org>