### PR TITLE
warn only once about the entity->rq->sched bug

### DIFF
--- a/drivers/gpu/drm/scheduler/sched_entity.c
+++ b/drivers/gpu/drm/scheduler/sched_entity.c
@@ -172,7 +172,7 @@ long drm_sched_entity_flush(struct drm_sched_entity *entity, long timeout)
 		 * BSDFIXME: When running glmark2, sched is null two times
 		 * whenever the program switches scenes
 		 */
-		DRM_ERROR("==========> BUG: entity->rq->sched is NULL\n");
+		DRM_WARN_ONCE("==========> BUG: entity->rq->sched is NULL\n");
 		return ret;
 	}
 	/**


### PR DESCRIPTION
Under KDE plasma the error is printed very often spamming the logs.
So, let's still remind about the problem, but do it just once.