### PR TITLE
Fix build after 1201523

### DIFF
--- a/drivers/gpu/drm/i915/i915_utils.h
+++ b/drivers/gpu/drm/i915/i915_utils.h
@@ -123,11 +123,13 @@ static inline u64 ptr_to_u64(const void *ptr)
 
 #include <linux/list.h>
 
+#if __FreeBSD_version < 1201523
 static inline int list_is_first(const struct list_head *list,
 				const struct list_head *head)
 {
 	return head->next == list;
 }
+#endif
 
 static inline void __list_del_many(struct list_head *head,
 				   struct list_head *first)

--- a/linuxkpi/gplv2/include/linux/pci.h
+++ b/linuxkpi/gplv2/include/linux/pci.h
@@ -172,6 +172,7 @@ pcie_get_readrq(struct pci_dev *dev)
 	return 128 << ((ctl & PCI_EXP_DEVCTL_READRQ) >> 12);
 }
 
+#if __FreeBSD_version < 1201523
 static inline void *
 pci_iomap(struct pci_dev *dev, int bar, unsigned long maxlen)
 {
@@ -184,5 +185,6 @@ pci_iounmap(struct pci_dev *dev, void *addr)
 {
 	/* NOP */
 }
+#endif
 
 #endif /* _LINUX_GPLV2_PCI_H_ */


### PR DESCRIPTION
I use this branch on almost all my H/W, except one notebook: https://github.com/FreeBSDDesktop/kms-drm/issues/142

This fix build issue on FreeBSD 12.1+.